### PR TITLE
Frontpage: align navbar cds icon to the left

### DIFF
--- a/assets/less/cds-rdm/globals/site.overrides
+++ b/assets/less/cds-rdm/globals/site.overrides
@@ -1,6 +1,6 @@
 .rdm-logo {
-  padding: 1em;
-  width: 200px;
+  padding: 1em 1em 1em 0;
+  width: 100px;
 }
 
 

--- a/templates/semantic-ui/invenio_app_rdm/frontpage.html
+++ b/templates/semantic-ui/invenio_app_rdm/frontpage.html
@@ -24,7 +24,7 @@
   {%- block grid_section %}
     <div class="ui container overlapping">
       <div class="ui stackable grid center-tablet-mobile">
-        <div class="column eight wide transparent-background pr-0 rel-pb-3">
+        <div class="column eight wide transparent-background pl-0 pr-0 rel-pb-3">
           <div class="highlight-background communities-box info-box rel-pb-3">
             <div class="ui grid middle aligned">
               <div class="sixteen wide column"><h2 class="ui header">Communities</h2>


### PR DESCRIPTION
closes: #43

![Screenshot from 2023-01-09 15-10-01](https://user-images.githubusercontent.com/25476209/211327380-75cd3159-cb5e-4474-8801-06cc3827d171.png)

