### PR TITLE
custom fields ui: add sorting by title

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -403,6 +403,7 @@ RDM_CUSTOM_FIELDS_UI = [
                     description="You should fill this field with one of the departments e.g BE, EN, HR etc.",
                     search=False,
                     multiple=True,
+                    sort_by="title_sort",
                     clearable=True,
                     autocompleteFrom="/api/vocabularies/departments",
                 )
@@ -423,6 +424,7 @@ RDM_CUSTOM_FIELDS_UI = [
                     description="You should fill this field with one of the recognised accelerators e.g LHC, SPS, PS, R&D etc.",
                     search=False,
                     multiple=True,
+                    sort_by="title_sort",
                     clearable=True,
                     type="text",
                     multiple_values=True,


### PR DESCRIPTION
* closes https://github.com/CERNDocumentServer/cds-rdm/issues/207

The fix was needed also for the `Accelerators` section. Seems like the `Experiments` section is already sorting the results while performing the search.
<img width="873" alt="Screenshot 2024-11-14 at 16 46 57" src="https://github.com/user-attachments/assets/7ba6507d-e83a-4fb9-930a-c8b1af37544d">
<img width="871" alt="Screenshot 2024-11-14 at 16 47 13" src="https://github.com/user-attachments/assets/97667dff-f03c-4d0e-ab06-b7dc3a197a40">
