### PR TITLE
pages: add terms of use and content policy static pages

### DIFF
--- a/app_data/pages.yaml
+++ b/app_data/pages.yaml
@@ -8,13 +8,11 @@
   description: Privacy notice page
   template: "empty.html" # see comment in the template
 - url: /terms
-  title: Terms of Use
   description: Terms of Use page
-  template: "empty.html" # see comment in the template
+  template: "terms_of_use.html"
 - url: /content-policy
-  title: Content policy
   description: Content Policy page
-  template: "empty.html" # see comment in the template
+  template: "content_policy.html"
 - url: /preservation-policy
   title: Preservation policy
   description: Preservation Policy page

--- a/app_data/pages/content_policy.html
+++ b/app_data/pages/content_policy.html
@@ -1,0 +1,158 @@
+<h1>CDS - Content Policy</h1>
+<a href="https://doi.org/10.17181/dd19c-hwf65"><img src="https://repository.cern/badge/DOI/10.17181/dd19c-hwf65.svg" alt="DOI"></a>
+
+<hr>
+
+<h2>Scope and Purpose</h2>
+<p>
+    The CERN Document Server (CDS) serves as a comprehensive institutional repository and dissemination platform for
+    the research and historical output produced by CERN, the European Organization for Nuclear Research, and CERN Experiments.
+    Below is an overview of its scope and purpose.
+</p>
+
+<h3>Scope</h3>
+<p>CDS preserves various digital objects that can be categorised as follows:</p>
+<ul>
+    <li><b>Scientific and Technical Content:</b> CDS covers a wide range of scientific and technical documents,
+      including research articles, conference papers, preprints, reports, slides, talks, theses, as well
+      as other research outputs like software, data, and more.
+    </li>
+    <li><b>Administrative Documents:</b> In addition to scientific and technical literature, CDS archives administrative
+      documents crucial for CERN's governance and operations. This includes policy statements, meeting minutes, human resources
+      materials, financial reports, and legal documents, providing transparency and accountability in CERN's management and
+      decision-making processes.
+    </li>
+    <li><b>Multidisciplinary Content:</b> While CERN is primarily focused on particle physics, CDS also includes content
+        from related disciplines such as accelerator physics, engineering, computing, etc.
+    </li>
+    <li><b>Historical Archive:</b> CDS contains historical documents and archival material related to the history of CERN,
+        including early research papers, technical reports, and institutional records.
+    </li>
+    <li><b>Multimedia Content:</b> CDS also hosts a variety of multimedia content related to scientific research,
+        educational outreach, and institutional events. This includes videos, presentations, images, audio recordings,
+        and interactive media, enriching the repository with diverse resources for knowledge dissemination, education,
+        and public engagement with particle physics and related fields.
+    </li>
+</ul>
+
+<h3>Purpose</h3>
+<ul>
+    <li><b>Institutional Repository:</b> CDS serves as a centralised platform for managing and preserving the scientific
+        output of CERN and its collaborators. It facilitates the discovery, access, and dissemination of research findings to
+        the global scientific community.
+    </li>
+    <li><b>Open Access:</b> CDS promotes open access to scientific information by providing free and unrestricted access
+        to its collection of documents whenever possible. This helps to maximise the impact and visibility of CERN's research output.
+    </li>
+    <li><b>Collaboration and Communication:</b> CDS fosters collaboration and communication among researchers by providing
+        tools for sharing, discussing, and collaborating on scientific documents.
+    </li>
+    <li><b>Archiving and Preservation:</b> CDS plays a crucial role in archiving and preserving the intellectual
+        heritage of CERN. It ensures the long-term accessibility and integrity of scientific and technical literature
+        produced by the organisation.
+    </li>
+    <li><b>Compliance and Reporting:</b> CDS helps CERN comply with institutional and funding agency policies
+        regarding research dissemination and reporting.
+    </li>
+</ul>
+
+<p>
+    Overall, CDS serves as a vital resource for researchers, students, educators, and the general public interested in
+    accessing and exploring the scientific achievements and advancements made at CERN over the years. It embodies CERN's
+    commitment to excellence in research, collaboration, and <a href="http://dx.doi.org/10.17181/CERN.RTIF.Z8BO">open science</a>.
+</p>
+
+<h2>Submission Requirements</h2>
+<ul>
+    <li><b>Eligibility:</b> Only CERN personnel and collaborators are permitted to submit content to the CDS.
+        Submissions from external parties are not accepted. Furthermore, regarding scientific outputs,
+        <a href="https://cds.cern.ch/record/1202777/files/CERN_Circ_Op_en_06.pdf">Operational Circular N.6</a> applies.
+    </li>
+    <li><b>Content Criteria:</b> All content submitted to CDS must be institutional in nature and of legitimate
+        interest to the organisation (therefore, personal content is not permitted). Submissions should be materials
+        worth preserving for the long term, including scientific and technical literature, administrative documents,
+        multimedia content, and other materials relevant to CERN's mission and activities.
+    </li>
+    <li><b>Quality Assurance:</b> Submissions may undergo review by relevant communities to ensure compliance with
+        CDS guidelines and relevance to CERN's objectives. Content deemed inappropriate or not meeting the criteria may be rejected.
+    </li>
+    <li><b>Metadata Requirements:</b> In order to increase discoverability of content, submitters are required
+        to provide accurate and complete metadata for each submission, including title, author(s), abstract, keywords,
+        and relevant classification information.
+    </li>
+    <li><b>Copyright and Licensing:</b> Submitters must ensure and warrant to CERN that they have all necessary
+        rights (including any required individual consents) to submit the uploaded content to CDS for open dissemination
+        and that they specify any copyright or licensing restrictions associated with such content. Use of CDS multimedia
+        content, is subject to the following terms of use: <a href="https://copyright.web.cern.ch/">https://copyright.web.cern.ch/</a>
+    </li>
+    <li><b>Ethical and Privacy Considerations:</b> In accordance with
+        <a href="https://cds.cern.ch/record/2240689/files/BrochureCodeofConductEN.pdf">CERN’s Code of Conduct</a>, submissions must
+        adhere to ethical standards and respect the rights and privacy of individuals mentioned or depicted in the content.
+    </li>
+    <li><b>Submission Process:</b> Content can be submitted to CDS through the designated submission interface
+        (Web UI or API), or via repository administrators in case assistance is needed.
+    </li>
+    <li><b>Compliance:</b> Submitters are expected to comply with all CDS policies, guidelines, and applicable
+        rules and regulations governing the submission and dissemination of CERN content.
+    </li>
+    <li><b>Continuous Improvement:</b> Guidelines are subject to periodic review and updates to reflect changes
+        in institutional priorities, technological advancements, and legal requirements. Feedback from users and
+        submitters is welcomed to improve the submission process and enhance the overall quality of the repository's content.
+    </li>
+</ul>
+
+<h2>Withdrawal and Removal</h2>
+<p>
+    CDS is dedicated to preserving and providing access to the valuable scholarly, historical, and administrative output
+    of CERN. As such, the content policy of CDS emphasises the long-term retention and accessibility of all submitted materials.
+    Users cannot delete content by themselves, reflecting our commitment to the enduring preservation of institutional knowledge.
+</p>
+
+<h3>Grace Period for Content Deletion</h3>
+<p>
+    Upon submission, content enters a grace period of one month during which it can be deleted upon request. If you need
+    to remove a submission within this period, please contact the CDS support line. Our team will assist you in processing
+    the deletion request promptly. This grace period allows for corrections and reconsiderations while ensuring that the
+    repository maintains accurate and reliable records.
+</p>
+
+<h3>Post-Grace Period Removal</h3>
+<p>
+    Once the grace period has elapsed, the ability to delete content is significantly restricted to uphold the integrity
+    and completeness of the repository. Content will only be removed by the CDS support team under specific circumstances, namely:
+</p>
+<ul>
+    <li><b>Breach of Terms:</b> If the content violates this policy, including the CDS Terms and Conditions,
+        it may be subject to removal at any time without notice. This includes issues related to where the content
+        was submitted without proper authorization or infringes on the intellectual property rights (i.e. copyright, etc.) of others.
+    </li>
+    <li><b>Data Privacy Concerns (OC11):</b> In compliance with Operational Circular No. 11, which governs data privacy
+        at CERN, content that compromises personal data or violates privacy regulations will be considered for removal.
+    </li>
+    <li><b>Restricted Content:</b> Content that has been marked as restricted and that has never been authorised
+        to be made public may be eligible for deletion upon valid request and evaluation.
+    </li>
+</ul>
+
+<h3>Procedure for Removal Requests</h3>
+<p>
+    For content removal requests beyond the grace period, please submit a
+    <a href="https://cern.service-now.com/service-portal?id=service_element&name=CDS-Service">support request</a> providing a
+    detailed explanation of the reason for the request, including any supporting documentation if applicable (e.g., evidence
+    of copyright infringement or privacy concerns). Each request will be carefully reviewed by the CDS administration team to ensure
+    compliance with our policies and legal obligations.
+</p>
+
+<h3>Commitment to Long-Term Preservation</h3>
+<p>
+    Our primary goal is to maintain a comprehensive and enduring repository that supports CERN's mission of advancing scientific
+    knowledge and preserving its institutional heritage. To this end, the content in CDS will be preserved for the lifetime
+    of the laboratory. By adhering to these withdrawal and removal policies, we aim to balance the need for flexibility with
+    the imperative of long-term and accurate content preservation.
+</p>
+
+<p>
+    For any questions or assistance regarding content withdrawal and removal, please <a href="https://cern.service-now.com/service-portal?id=service_element&name=CDS-Service">contact the CDS support team</a>.
+</p>
+
+<br />

--- a/app_data/pages/terms_of_use.html
+++ b/app_data/pages/terms_of_use.html
@@ -1,0 +1,51 @@
+<h1>CDS - Terms and Conditions</h1>
+<a href="https://doi.org/10.17181/53y0h-6ad63"><img src="https://repository.cern/badge/DOI/10.17181/53y0h-6ad63.svg" alt="DOI"></a>
+
+<br />
+<br />
+
+<p>Use of the CERN Document Server service (hereafter “CDS”) denotes agreement with the following terms of use:</p>
+<ul>
+    <li>
+        CDS is provided free of charge. It serves as a comprehensive institutional repository and dissemination
+        platform for the research and historical output produced by CERN, the European Organization for Nuclear Research,
+        and its members of personnel. See <a href="https://doi.org/10.17181/dd19c-hwf65">Content Policy</a> for more details.
+    </li>
+    <li>
+        By uploading content to CDS, the content provider affirms that such content complies with all
+        applicable laws, licence conditions and third party rights, and shall hold CERN free and harmless from any related liability.
+    </li>
+    <li>
+        All content is provided “as is” and without warranty of any kind. The user shall hold CERN and individual content
+        providers free and harmless from any related liability in connection with its use of such content.
+    </li>
+    <li>
+        Users shall respect copyright and all applicable licence conditions. The download and use of content from CDS does
+        not amount to a transfer of intellectual property.
+    </li>
+    <li>
+        CERN reserves the right, without notice or liability, and at its sole discretion, to restrict or remove a user's access
+        or remove any uploaded content, where it considers that use of CDS interferes with its operations or violates these
+        Terms and Conditions, and/or applicable laws.
+    </li>
+    <li>
+        CERN bases CDS on leading technologies and architectures, operated within the limits of its financial and human
+        resources and made available by CERN on an "as is” and "best efforts” basis. Access to, availability and use of
+        CDS is not guaranteed nor can be expected.
+    </li>
+    <li>
+        CERN excludes and disclaims all liability for damage resulting from users’ access, or inability to access, or use of CDS.
+    </li>
+    <li>
+        These terms and conditions of use are subject to change by CERN at any time and without notice, other than through posting
+        the updated terms on the CDS website. Any revised terms and conditions of use shall become effective immediately upon posting.
+    </li>
+</ul>
+
+<p>
+    If you have any questions or comments with respect to CDS, or if you are unsure whether your intended use is in line with
+    these Terms and Conditions, or if you seek permission for a use that does not fall within these Terms and Conditions, please
+    <a href="https://cern.service-now.com/service-portal?id=service_element&name=CDS-Service">contact support</a>.
+</p>
+
+<br />


### PR DESCRIPTION
* closes https://github.com/CERNDocumentServer/cds-rdm/issues/160

Terms and use:
<img width="1430" alt="Screenshot 2024-12-12 at 18 11 52" src="https://github.com/user-attachments/assets/e94f71fe-f4d2-4816-8dff-dc73f59ca80d" />

Content policy:
<img width="1350" alt="Screenshot 2024-12-12 at 18 12 54" src="https://github.com/user-attachments/assets/70747376-76a1-4779-8d29-50946b7831b0" />
<img width="1311" alt="Screenshot 2024-12-12 at 18 12 36" src="https://github.com/user-attachments/assets/c35b7149-e509-4a99-ad6e-53503e257c6a" />
<img width="1415" alt="Screenshot 2024-12-12 at 18 13 18" src="https://github.com/user-attachments/assets/8492b149-c3b1-4947-a1c4-d4442cb89d36" />
<img width="1445" alt="Screenshot 2024-12-12 at 18 13 37" src="https://github.com/user-attachments/assets/7febe9da-7e46-4a88-89a3-40cd77a581e3" />

