### PR TITLE
stats: move the description of newly added fields to init

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -199,10 +199,6 @@ DATACITE_PREFIX = ""
 DATACITE_TEST_MODE = True
 DATACITE_DATACENTER_SYMBOL = ""
 
-RDM_PERSISTENT_IDENTIFIERS["doi"]["required"] = False
-RDM_PERSISTENT_IDENTIFIERS["doi"]["ui"]["default_selected"] = "not_needed"  # "yes", "no" or "not_needed"
-RDM_PARENT_PERSISTENT_IDENTIFIERS["doi"]["required"] = False
-
 # Authentication - Invenio-Accounts and Invenio-OAuthclient
 # =========================================================
 # See: https://inveniordm.docs.cern.ch/customize/authentication/
@@ -519,6 +515,7 @@ RDM_RECORDS_PERSONORG_SCHEMES = {**RDM_RECORDS_PERSONORG_SCHEMES,
 RDM_PERSISTENT_IDENTIFIERS["doi"]["required"] = False
 RDM_PARENT_PERSISTENT_IDENTIFIERS["doi"]["required"] = False
 RDM_PERSISTENT_IDENTIFIERS["doi"]["ui"]["default_selected"] = "not_needed"  # "yes", "no" or "not_needed"
+
 # Invenio-Preservation-Sync
 # =========================
 

--- a/site/cds_rdm/stats/templates/events/__init__.py
+++ b/site/cds_rdm/stats/templates/events/__init__.py
@@ -5,4 +5,13 @@
 # CDS-RDM is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-"""Statistics events search index templates."""
+"""Statistics events search index templates.
+
+The templates were overridden to include the custom fields in the search index.
+
+Specifically, the following fields were added to the search index:
+
+- `is_lcds` (boolean): This field marks all statistical events that have been migrated from the legacy CDS system.
+- `before_COUNTER` (boolean): This field applies to all migrated events where no information was available to determine whether they were human or robot events. This was later resolved with the implementation of a proper robot-checking mechanism, ensuring COUNTER compliance.
+
+"""

--- a/site/cds_rdm/stats/templates/events/file_download/os-v2/file-download-v1.0.0.json
+++ b/site/cds_rdm/stats/templates/events/file_download/os-v2/file-download-v1.0.0.json
@@ -86,12 +86,10 @@
         "type": "boolean"
       },
       "is_lcds": {
-        "type": "boolean",
-        "description": "This field marks all statistical events that have been migrated from the legacy CDS system."
+        "type": "boolean"
       },
       "before_COUNTER": {
-        "type": "boolean",
-        "description": "This field applies to all migrated events where no information was available to determine whether they were human or robot events. This was later resolved with the implementation of a proper robot-checking mechanism, ensuring COUNTER compliance."
+        "type": "boolean"
       },
       "updated_timestamp": {
         "type": "date"

--- a/site/cds_rdm/stats/templates/events/record_view/os-v2/record-view-v1.0.0.json
+++ b/site/cds_rdm/stats/templates/events/record_view/os-v2/record-view-v1.0.0.json
@@ -66,12 +66,10 @@
         "type": "boolean"
       },
       "is_lcds": {
-        "type": "boolean",
-        "description": "This field marks all statistical events that have been migrated from the legacy CDS system."
+        "type": "boolean"
       },
       "before_COUNTER": {
-        "type": "boolean",
-        "description": "This field applies to all migrated events where no information was available to determine whether they were human or robot events. This was later resolved with the implementation of a proper robot-checking mechanism, ensuring COUNTER compliance."
+        "type": "boolean"
       },
       "updated_timestamp": {
         "type": "date"


### PR DESCRIPTION
The description added for the custom fields in the statistic event mappings cause problems when initiating the templates. This PR is moving the comment in the `events/__init__.py` file.