### PR TITLE
dockerpublish: fix tagging rules

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -40,12 +40,12 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern={{version}}
-            # set latest tag for default branch (master)
-            type=raw,value=latest,enable={{is_default_branch}}
+            # set tag version if a tag is present. We use type=raw to avoid generate the latest tag automatically
+            type=raw,value={{tag}},enable=${{ startsWith(github.ref, 'refs/tags/')}}
+            # set latest tag for master branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
             # set "latest" tags for maint branches
-            type=raw,value={{branch}}-latest,enable=${{ github.event_name != 'push tag' && github.ref != format('refs/heads/{0}', 'master') }}
-
+            type=raw,value={{branch}}-latest,enable=${{ startsWith(github.ref, 'refs/heads/') && github.ref != 'refs/heads/master' }}
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
Latest tag was automatically generated for [`type=semver`](https://github.com/docker/metadata-action?tab=readme-ov-file#latest-tag) and although that was fine for master branch, we don't want that for maint branches where we tag a commit there.