### PR TITLE
WIP: User ID validator for GitLab

### DIFF
--- a/site/cds_rdm/errors.py
+++ b/site/cds_rdm/errors.py
@@ -20,3 +20,22 @@ class RequestError(GroupSyncingError):
     def __init__(self, url, error_details):
         """Initialise error."""
         super().__init__(_(f"Request error on {url}.\n Error details: {error_details}"))
+
+
+class KeycloakIdentityNotFoundError(Exception):
+    def __init__(self, user_id: str) -> None:
+        super().__init__(_(f"Could not find CERN SSO identity for user {user_id}"))
+
+
+class GitLabIdentityNotFoundError(Exception):
+    def __init__(self, user_id: str) -> None:
+        super().__init__(_(f"GitLab user {user_id} did not have CERN SSO identity"))
+
+
+class KeycloakGitLabMismatchError(Exception):
+    def __init__(self, gitlab_user_id: str, cds_user_id: str) -> None:
+        super().__init__(
+            _(
+                f"GitLab user {gitlab_user_id} has a different CERN SSO identity to currently signed-in CDS user {cds_user_id}"
+            )
+        )

--- a/site/cds_rdm/vcs/handlers.py
+++ b/site/cds_rdm/vcs/handlers.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from flask_login import current_user
+from invenio_cern_sync.sso import cern_remote_app_name
+from invenio_oauthclient import current_oauthclient
+
+from cds_rdm.errors import (
+    GitLabIdentityNotFoundError,
+    KeycloakGitLabMismatchError,
+    KeycloakIdentityNotFoundError,
+)
+
+
+def gitlab_account_info_serializer(original_serializer):
+    def inner(remote, resp, user_info, **kwargs):
+        cern_client_id = current_oauthclient.oauth.remote_apps.get(
+            cern_remote_app_name
+        ).consumer_key
+
+        user_keycloak_id: str | None = None
+        for remote_account in current_user.remote_accounts:
+            if remote_account.client_id == cern_client_id:
+                user_keycloak_id = remote_account.extra_data.get("keycloak_id")
+
+        if user_keycloak_id is None:
+            raise KeycloakIdentityNotFoundError(current_user.id)
+
+        gl_user_id = str(user_info["id"])
+        gl_identities = user_info["identities"]
+        gl_extern_uid: str | None = None
+        for identity in gl_identities:
+            if identity["provider"] != "openid_connect":
+                continue
+
+            gl_extern_uid = identity["extern_uid"]
+
+        if gl_extern_uid is None:
+            raise GitLabIdentityNotFoundError(gl_user_id)
+
+        if user_keycloak_id != gl_extern_uid:
+            raise KeycloakGitLabMismatchError(gl_user_id, current_user.id)
+
+        return original_serializer(remote, resp, user_info, **kwargs)
+
+    return inner


### PR DESCRIPTION
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/552

---

* The new OAuth remote for GitLab will use the same system as all other remotes (i.e. being registered via `invenio-oauthclient`). This will allow us to plug in custom handlers at various points. Notably, we can override the GitLab-specific [`account_info_serializer` function](https://github.com/inveniosoftware/invenio-github/pull/190/commits/1354e805268736a9c7a56568aa9eb44f1c572268#diff-e7111d63b6d13c1d6a2a3b3369b3afb91789b22ff924f58e930352255de95964R81-R92) and perform our own validation on the raw `userinfo` object, even before it gets turned into the generic object with significantly less information.
* GitLab returns an `identities` field in the `userinfo`, containing a list of external authentication providers the user has linked to their account, and the ID each provider uses to represent the user. 
  
    For example:

    ```json
    {
        "id": 1234,
        "username": "johnsmith",
        "identities": [
            {
                "provider": "openid_connect",
                "extern_uid": "johnsmith",
                "saml_provider_id": null,
            },
            {
                "provider": "ldapmain",
                "extern_uid": "cn=johnsmith,ou=users,ou=organic units,dc=cern,dc=ch",
                "saml_provider_id": null,
            },
            {
                "provider": "kerberos",
                "extern_uid": "johnsmith@CERN.CH",
                "saml_provider_id": null,
            },
        ],
        ...
    }
    ```
    
    In this case, we can see the GitLab user `johnsmith` has a CERN username of `johnsmith`. It is possible for the GitLab username to be different to the CERN username, so we cannot simply rely on the GitLab username.

* We already store the user's CERN username in the database as part of the `extra_data` field for the CERN/keycloak [`RemoteAccount`](https://github.com/inveniosoftware/invenio-oauthclient/blob/master/invenio_oauthclient/models.py#L29). We just have to look this up (based on the OAuth client ID of the CERN remote app) and compare the two values.

* This way, we ensure the user has logged in with the GitLab account associated with the same CERN account as their CDS account, which avoids some security issues and bugs.