### PR TITLE
components: ensure unique cdsrn

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -57,6 +57,7 @@ from invenio_app_rdm.config import VOCABULARIES_DATASTREAM_WRITERS as DEFAULT_VO
 from cds_rdm.clc_sync.services.components import ClcSyncComponent
 from cds_rdm.components import CDSResourcePublication
 from cds_rdm.components import SubjectsValidationComponent
+from cds_rdm.components import MintAlternateIdentifierComponent
 from cds_rdm.pids import validate_optional_doi_transitions
 from cds_rdm.views import frontpage_view_function
 
@@ -325,6 +326,8 @@ CDS_EOS_OFFLOAD_REDIRECT_BASE_PATH = ""
 CDS_CERN_SCIENTIFIC_COMMUNITY_ID = "CHANGE_ME"
 """The id of the CERN Scientific community."""
 
+CDS_CERN_ALTERNATE_IDENTIFIERS_TO_MINT = {"cdsrn": "CDS Reference"}
+
 CHECKS_ENABLED = True
 """Enable metadata checks."""
 
@@ -403,7 +406,7 @@ RDM_FILES_DEFAULT_MAX_FILE_SIZE = 50 * 10 ** 9  # 50GB
 JOBS_ADMINISTRATION_ENABLED = True
 
 RDM_RECORDS_IDENTIFIERS_SCHEMES = {**RDM_RECORDS_IDENTIFIERS_SCHEMES,
-                                   **{"cds_ref": {"label": _("CDS Reference"),
+                                   **{"cdsrn": {"label": _("CDS Reference"),
                                                   "validator": always_valid,
                                                   "datacite": "CDS"},
                                       "aleph": {"label": _("Aleph number"),
@@ -443,6 +446,7 @@ RDM_RECORDS_SERVICE_COMPONENTS = [
     *DefaultRecordsComponents,
     CDSResourcePublication,
     ClcSyncComponent,
+    MintAlternateIdentifierComponent,
 ]
 
 

--- a/site/cds_rdm/components.py
+++ b/site/cds_rdm/components.py
@@ -8,16 +8,22 @@
 
 """CDS RDM service components."""
 
+from cds_rdm.minters import alternate_identifier_minter
 from celery import shared_task
 from flask import current_app
 from invenio_access.permissions import system_identity
 from invenio_communities.proxies import current_communities
-from invenio_drafts_resources.services.records.components import ServiceComponent
+from invenio_drafts_resources.services.records.components import \
+    ServiceComponent
+from invenio_i18n import gettext as _
 from invenio_i18n import lazy_gettext as _
+from invenio_pidstore.models import PersistentIdentifier
 from invenio_rdm_records.proxies import current_rdm_records
-from invenio_rdm_records.services.errors import ValidationErrorWithMessageAsList
+from invenio_rdm_records.services.errors import \
+    ValidationErrorWithMessageAsList
 from invenio_records_resources.services.uow import TaskOp
 from marshmallow import ValidationError
+from sqlalchemy import and_, or_
 
 # @shared_task()
 # def create_community_inclusion_request(record_id):
@@ -130,3 +136,54 @@ class SubjectsValidationComponent(ServiceComponent):
             draft.metadata.get("subjects", []),
             record.get("metadata", {}).get("subjects", []),
         )
+
+
+class MintAlternateIdentifierComponent(ServiceComponent):
+    """Service component for minting alternative identifiers."""
+
+    def update_draft(self, identity, data=None, record=None, errors=None, **kwargs):
+        """Ensure uniqueness of alternative identifiers on update."""
+        alt_id_scheme_names = current_app.config[
+            "CDS_CERN_alternate_identifierS_TO_MINT"
+        ]
+        alternate_identifiers = {
+            id["scheme"]: id["identifier"]
+            for id in data["metadata"].get("identifiers", [])
+            if id["scheme"] in alt_id_scheme_names.keys()
+        }
+
+        # Bulk query for all alternative identifiers to ensure uniqueness across all records
+        if alternate_identifiers:
+            # Build a filter that checks for any (pid_type, pid_value) pair in alternate_identifiers
+            filters = [
+                or_(
+                    *[
+                        and_(
+                            PersistentIdentifier.pid_type == scheme,
+                            PersistentIdentifier.pid_value == value,
+                        )
+                        for scheme, value in alternate_identifiers.items()
+                    ]
+                ),
+                PersistentIdentifier.object_type == "rec",
+                PersistentIdentifier.object_uuid != record.pid.object_uuid,
+            ]
+            existing_pids = PersistentIdentifier.query.filter(*filters).all()
+            # Build a set of (scheme, value) pairs that already exist
+            existing_pairs = {(pid.pid_type, pid.pid_value) for pid in existing_pids}
+            for scheme, value in alternate_identifiers.items():
+                if (scheme, value) in existing_pairs:
+                    errors.append(
+                        {
+                            "field": "metadata.identifiers",
+                            "messages": [
+                                _(
+                                    f"Identifier value '{value}' for scheme '{alt_id_scheme_names[scheme]}' already exists."
+                                )
+                            ],
+                        }
+                    )
+
+    def publish(self, identity, draft=None, record=None, **kwargs):
+        """Mint alternative identifiers on publish."""
+        alternate_identifier_minter(uuid=record.pid.object_uuid, draft=draft)

--- a/site/cds_rdm/minters.py
+++ b/site/cds_rdm/minters.py
@@ -8,7 +8,10 @@
 
 """Minters."""
 
+from flask import current_app
+from invenio_db import db
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
+from sqlalchemy import and_, or_
 
 
 def legacy_recid_minter(legacy_recid, uuid):
@@ -20,3 +23,46 @@ def legacy_recid_minter(legacy_recid, uuid):
         object_uuid=uuid,
         status=PIDStatus.REGISTERED,
     )
+
+
+def alternate_identifier_minter(uuid, draft):
+    """Alternative identifier minter."""
+    alt_id_scheme_names = current_app.config["CDS_CERN_ALTERNATE_IDENTIFIERS_TO_MINT"]
+    alternate_identifiers = {
+        id["scheme"]: id["identifier"]
+        for id in draft["metadata"].get("identifiers", [])
+        if id["scheme"] in alt_id_scheme_names.keys()
+    }
+
+    # Query all existing PIDs for the CURRENT record and these schemes
+    existing_pids = {
+        pid.pid_type: pid
+        for pid in PersistentIdentifier.query.filter(
+            PersistentIdentifier.object_type == "rec",
+            PersistentIdentifier.object_uuid == uuid,
+            PersistentIdentifier.pid_type.in_(alt_id_scheme_names.keys()),
+        )
+    }
+
+    # Delete PIDs in DB that are not present in the data anymore
+    for scheme, pid in existing_pids.items():
+        if scheme not in alternate_identifiers:
+            db.session.delete(pid)
+            db.session.commit()
+
+    # Update existing PIDs if the value has changed, or add new ones if they are not present
+    for scheme, value in alternate_identifiers.items():
+        pid = existing_pids.get(scheme, None)
+        if pid:
+            if pid.pid_value != value:
+                pid.pid_value = value
+                pid.status = PIDStatus.REGISTERED
+                db.session.commit()
+        else:
+            PersistentIdentifier.create(
+                pid_type=scheme,
+                pid_value=value,
+                object_type="rec",
+                object_uuid=uuid,
+                status=PIDStatus.REGISTERED,
+            )


### PR DESCRIPTION
closes: https://github.com/CERNDocumentServer/cds-rdm/issues/370

1. Renamed cds_ref -> cdsrn
2. Added component to mint `cdsrn` pid_type

Steps:
1. Merge this PR
2. Run the following scripts (It will automatically mint pids for the existing ones as it uses the service layer.

```python
# Script to update cds_ref to cdsrn and mint cdsrn
from invenio_access.permissions import system_identity
from invenio_rdm_records.proxies import current_rdm_records_service

# Records, run after deploying changes: 1. cds_ref to cdsrn, 2. service component to mint cdsrn
hits = current_rdm_records_service.search(system_identity, params={"q": "metadata.identifiers.scheme:cds_ref"})
for hit in hits:
    draft = current_rdm_records_service.edit(system_identity, hit['id'])
    for identifier in draft.data["metadata"].get("identifiers", []):
        if identifier.get("scheme") == "cds_ref":
            identifier["scheme"] = "cdsrn"
    updated_draft = current_rdm_records_service.update_draft(system_identity, draft.id, draft.data)
    current_rdm_records_service.publish(system_identity, updated_draft.id)

# Drafts
hits = current_rdm_records_service.search_drafts(system_identity, params={"q": "metadata.identifiers.scheme:cds_ref"})
for hit in hits:
    draft = current_rdm_records_service.edit(system_identity, hit['id'])
    for identifier in draft.data["metadata"].get("identifiers", []):
        if identifier.get("scheme") == "cds_ref":
            identifier["scheme"] = "cdsrn"
    updated_draft = current_rdm_records_service.update_draft(system_identity, draft.id, draft.data)

```