### PR TITLE
custom_fields: add administrative unit to cern fields

### DIFF
--- a/assets/templates/custom_fields/CERNFields.js
+++ b/assets/templates/custom_fields/CERNFields.js
@@ -17,6 +17,7 @@ export class CERNFields extends Component {
   feedbackCfg = {
     "cern-information-section": [
       "custom_fields.cern:programmes",
+      "custom_fields.cern:administrative_unit",
       "custom_fields.cern:department",
       "custom_fields.cern:experiments",
       "custom_fields.cern:accelerators",
@@ -31,6 +32,7 @@ export class CERNFields extends Component {
     const { key, children, label, active } = this.props;
     const [
       department,
+      administrativeUnit,
       programme,
       accelerator,
       experiment,
@@ -48,7 +50,8 @@ export class CERNFields extends Component {
         id="cern-information-section"
       >
         <Grid padded>
-          <Grid.Column computer={16}>{department}</Grid.Column>
+          <Grid.Column computer={8}>{department}</Grid.Column>
+          <Grid.Column computer={8}>{administrativeUnit}</Grid.Column>
           <Grid.Column computer={16}>{programme}</Grid.Column>
         </Grid>
         <FieldLabel htmlFor="CERNFields" icon="bullseye" label="Physics" />

--- a/site/cds_rdm/custom_fields/cern.py
+++ b/site/cds_rdm/custom_fields/cern.py
@@ -24,6 +24,7 @@ CERN_CUSTOM_FIELDS = [
         dump_options=True,
         multiple=True,
     ),
+    KeywordCF(name="cern:administrative_unit"),
     VocabularyCF(
         name="cern:accelerators",
         vocabulary_id="accelerators",
@@ -64,6 +65,17 @@ CERN_CUSTOM_FIELDS_UI = {
                 sort_by="title_sort",
                 clearable=True,
                 autocompleteFrom="/api/vocabularies/departments",
+            ),
+        ),
+        dict(
+            field="cern:administrative_unit",
+            ui_widget="Input",
+            props=dict(
+                label="Administrative Unit",
+                icon="clipboard",
+                description="Optionally provide the detailed administrative unit: group-section.",
+                sort_by="title_sort",
+                clearable=True,
             ),
         ),
         dict(


### PR DESCRIPTION
Closes issue: https://github.com/CERNDocumentServer/cds-rdm/issues/550
<img width="1120" height="223" alt="Screenshot 2025-09-22 at 09 36 50" src="https://github.com/user-attachments/assets/cc08e408-b357-4fe9-b6c1-8bfcf0c63bb4" />
<img width="425" height="256" alt="Screenshot 2025-09-22 at 09 37 00" src="https://github.com/user-attachments/assets/c0eb678a-806d-4c46-8fe6-c9e7f090103d" />
