### PR TITLE
resource-types: added new types for periodicals and brochure

### DIFF
--- a/app_data/vocabularies/resource_types.yaml
+++ b/app_data/vocabularies/resource_types.yaml
@@ -700,7 +700,6 @@
     de: Foto
     cs: Fotografie
   tags:
-    - depositable
     - linkable
 - id: image-other
   icon: chart bar outline


### PR DESCRIPTION
Partially closes issue: https://github.com/CERNDocumentServer/cds-migrator-kit/issues/335