### PR TITLE
add(clc sync): link to remove sync

### DIFF
--- a/assets/js/components/record_details/clc_sync.js
+++ b/assets/js/components/record_details/clc_sync.js
@@ -168,6 +168,38 @@ export class CLCSync extends Component {
     ) : null;
   };
 
+  removeSync = async () => {
+    const { clcSyncRecord } = this.state;
+    if (!clcSyncRecord?.id) {
+      return;
+    }
+
+    this.setState({ loading: true, error: null });
+
+    try {
+      this.cancellableRequest = withCancel(
+        http.delete(`/api/clc/${clcSyncRecord.id}`, {
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+        })
+      );
+      await this.cancellableRequest.promise;
+
+      this.setState({
+        clcSyncRecord: null,
+        autoSync: null,
+      });
+      this.setSuccessMessage();
+    } catch (error) {
+      console.error("Error removing CLC sync:", error);
+      this.setState({ error: error });
+    } finally {
+      this.setState({ loading: false });
+    }
+  };
+
   render() {
     const { error, loading, autoSync, clcSyncRecord, showSuccess } = this.state;
 
@@ -213,6 +245,27 @@ export class CLCSync extends Component {
             <Icon name="sync alternate" />
             {i18next.t("Resync")}
           </Button>
+          <Popup
+            content={
+              <>
+                <Icon name="warning sign" color="orange" />{" "}
+                {i18next.t("Remove CLC sync")}
+              </>
+            }
+            trigger={
+              <Button
+                size="tiny"
+                icon
+                loading={loading}
+                onClick={this.removeSync}
+                disabled={loading}
+                negative
+                className="ml-10"
+              >
+                <Icon name="trash" />
+              </Button>
+            }
+          />
         </div>
         {clcSyncRecord && (
           <p className="text-align-center mt-10">


### PR DESCRIPTION
Only added to UI:
<img width="416" height="112" alt="Screenshot 2025-12-11 at 17 01 17" src="https://github.com/user-attachments/assets/73afb686-bce0-49c2-88c7-ea3683ea9012" />

<img width="409" height="122" alt="Screenshot 2025-12-11 at 17 02 25" src="https://github.com/user-attachments/assets/f4a79412-2b7d-4b22-b63c-1868d23c7abc" />

[Backend](https://github.com/CERNDocumentServer/cds-rdm/blob/master/site/cds_rdm/clc_sync/services/service.py#L102-L110), [tests](https://github.com/CERNDocumentServer/cds-rdm/blob/master/site/tests/clc_sync/test_clc_services.py#L53-L58) were already implemented.