### PR TITLE
feat(records): customize file display name

### DIFF
--- a/templates/semantic-ui/invenio_app_rdm/records/macros/files/file_list.html
+++ b/templates/semantic-ui/invenio_app_rdm/records/macros/files/file_list.html
@@ -1,0 +1,96 @@
+{#
+  Copyright (C) 2020-2025 CERN.
+  Copyright (C) 2023 Northwestern University.
+  Copyright (C) 2021 Graz University of Technology.
+  Copyright (C) 2021 TU Wien.
+  Copyright (C) New York University.
+
+  Invenio RDM Records is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{%- macro file_list(
+    files, pid, is_preview, include_deleted,
+    record=None,
+    with_preview=true,
+    download_endpoint='invenio_app_rdm_records.record_file_download',
+    preview_endpoint='invenio_app_rdm_records.record_file_preview',
+    is_media=false,
+    permissions=None
+    ) %}
+    <table class="ui striped table files fluid {{ record.ui.access_status.id }}">
+        <thead>
+            <tr>
+                <th>{{ _("Name") }}</th>
+                <th>{{ _("Size") }}</th>
+                <th class>
+                    {%- if config.RDM_ARCHIVE_DOWNLOAD_ENABLED %}
+                        {% set archive_download_url = record.links.archive_media if is_media else record.links.archive %}
+                        <a role="button"
+                           class="ui compact mini button right floated archive-link"
+                           href="{{ archive_download_url }}">
+                            <i class="file archive icon button" aria-hidden="true"></i> {{ _("Download all") }}
+                        </a>
+                    {%- endif %}
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            {%- set binary_sizes = not config.APP_RDM_DISPLAY_DECIMAL_FILE_SIZES %}
+            {%- set include_deleted_value = 0 -%}
+            {% if include_deleted %}
+                {%- set include_deleted_value = 1 -%}
+            {% endif %}
+            {% for file in files %}
+                {% if not file.access.hidden %}
+                    {%- set is_remote_file = file.transfer.type == transfer_types.REMOTE %}
+                    {%- set display_name = file.metadata.description or file.key %}
+                    {% if is_preview %}
+                        {%- set file_url_download = url_for(download_endpoint, pid_value=pid, filename=file.key, download=1, preview=1) %}
+                        {%- set file_url_preview = url_for(preview_endpoint, pid_value=pid, filename=file.key, preview=1, include_deleted=include_deleted_value) %}
+                    {% else %}
+                        {%- set file_url_download = url_for(download_endpoint, pid_value=pid, filename=file.key, download=1) %}
+                        {%- set file_url_preview = url_for(preview_endpoint, pid_value=pid, filename=file.key, include_deleted=include_deleted_value) %}
+                    {% endif %}
+                    {%- set file_type = file.key.split('.')[-1] %}
+                    <tr>
+                        <td class="ten wide">
+                            <div>
+                                <a href="{{ file_url_download }}">{{ display_name }}</a>
+                            </div>
+                            {%- if not is_remote_file %}
+                                <small class="ui text-muted font-tiny">{{ file.checksum or _("Checksum not yet calculated.") }}
+                                    <div class="ui icon inline-block"
+                                         data-tooltip="{{ _("This is the file fingerprint (checksum), which can be used to verify the file integrity.") }}">
+                                        <i class="question circle checksum icon"></i>
+                                    </div>
+                                </small>
+                            {%- endif %}
+                        </td>
+                        <td>
+                            {%- if is_remote_file %}{{ _("N/A (external)") }}{%- else -%}{{ file.size|filesizeformat(binary=binary_sizes) }}{%- endif %}
+                            </td>
+                            <td class="right aligned">
+                                <span>
+                                    {% if with_preview and file_type|lower is previewable and not is_remote_file %}
+                                        <a role="button"
+                                           class="ui compact mini button preview-link"
+                                           href="{{ file_url_preview }}"
+                                           target="preview-iframe"
+                                           data-file-key="{{ file.key }}">
+                                            <i class="eye icon" aria-hidden="true"></i>{{ _("Preview") }}
+                                        </a>
+                                    {% endif %}
+                                    <a role="button"
+                                       class="ui compact mini button"
+                                       href="{{ file_url_download }}">
+                                        <i class="download icon" aria-hidden="true"></i>{{ _("Download") }}
+                                    </a>
+                                </span>
+                            </td>
+                        </tr>
+                    {% endif %}
+                {% endfor %}
+            </tbody>
+        </table>
+    {%- endmacro %}

--- a/templates/semantic-ui/invenio_app_rdm/records/macros/files/preview_file_box.html
+++ b/templates/semantic-ui/invenio_app_rdm/records/macros/files/preview_file_box.html
@@ -1,0 +1,52 @@
+{#
+  Copyright (C) 2020-2025 CERN.
+  Copyright (C) 2023 Northwestern University.
+  Copyright (C) 2021 Graz University of Technology.
+  Copyright (C) 2021 TU Wien.
+  Copyright (C) New York University.
+
+  Invenio RDM Records is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% from "invenio_app_rdm/records/macros/files/preview_file.html" import preview_file with context %}
+
+{% macro preview_file_box(file, pid, is_preview, record, include_deleted) %}
+    {%- set is_remote_file = file.transfer.type == transfer_types.REMOTE %}
+    {%- set display_name = file.metadata.description or file.key %}
+    <div class="ui accordion panel mb-10 {{ record.ui.access_status.id }}"
+         href="#files-preview-accordion-panel">
+        <h3 class="active title panel-heading {{ record.ui.access_status.id }} m-0">
+            <div role="button"
+                 id="files-preview-accordion-trigger"
+                 aria-controls="files-preview-accordion-panel"
+                 aria-expanded="true"
+                 tabindex="0"
+                 class="trigger"
+                 aria-label="{{ _("File preview") }}">
+                <span id="preview-file-title">{{ display_name }}</span>
+                <i class="angle right icon" aria-hidden="true"></i>
+            </div>
+        </h3>
+        <div role="region"
+             id="files-preview-accordion-panel"
+             aria-labelledby="files-preview-accordion-trigger"
+             class="active content preview-container pt-0 {{ record.ui.access_status.id }}">
+            {%- if is_remote_file %}
+                <div class="ui info message">
+                    <div class="header">{{ _("This file cannot be previewed") }}</div>
+                    <ul class="list">
+                        <li>
+                            {{ _('This file is an external reference and not stored directly in this repository.
+                                                        To access its content, please download it and open it locally.') }}
+                        </li>
+                    </ul>
+                </div>
+            {%- else %}
+                <div>
+                    {{ preview_file('invenio_app_rdm_records.record_file_preview', pid_value=pid, filename=file.key, is_preview=is_preview, include_deleted=include_deleted) }}
+                </div>
+            {%- endif %}
+        </div>
+    </div>
+{%- endmacro %}


### PR DESCRIPTION
Overrided file list and preview templates to show `file.metadata.description` as the file name when available

<img width="531" height="292" alt="Screenshot 2025-12-15 at 14 35 35" src="https://github.com/user-attachments/assets/2a008781-8697-4898-9bff-ce017937e279" />
<img width="875" height="269" alt="Screenshot 2025-12-15 at 14 35 59" src="https://github.com/user-attachments/assets/51a9faaf-a740-4153-a407-c7668c7b5f1d" />
<img width="850" height="255" alt="Screenshot 2025-12-15 at 14 38 38" src="https://github.com/user-attachments/assets/eff2ba77-ddd8-42ce-b238-ec078400ab4a" />
