### PR TITLE
feat(records): customize file display name

### DIFF
--- a/site/cds_rdm/templates/semantic-ui/cds_rdm/records/detail.html
+++ b/site/cds_rdm/templates/semantic-ui/cds_rdm/records/detail.html
@@ -26,3 +26,15 @@
 </div>
 {% endif %}
 {%- endblock record_content -%}
+
+{% macro display_name(file) %}
+  {{ file.metadata.description or file.key }}
+{% endmacro %}
+
+{%- block record_file_preview -%}
+    {{ preview_file_box(files_ns.preview_file, record_ui["id"], is_preview, record, include_deleted, display_name=display_name) }}
+{%- endblock record_file_preview -%}
+
+{%- block record_file_list -%}
+    {{ file_list_box(files_ns.files, record_ui["id"], is_preview, include_deleted, record, permissions, display_name=display_name) }}
+{%- endblock record_file_list -%}


### PR DESCRIPTION
closes https://github.com/CERNDocumentServer/cds-rdm/issues/652

Overrided file list and preview templates to show `file.metadata.description` as the file name when available

<img width="531" height="292" alt="Screenshot 2025-12-15 at 14 35 35" src="https://github.com/user-attachments/assets/2a008781-8697-4898-9bff-ce017937e279" />
<img width="875" height="269" alt="Screenshot 2025-12-15 at 14 35 59" src="https://github.com/user-attachments/assets/51a9faaf-a740-4153-a407-c7668c7b5f1d" />
<img width="850" height="255" alt="Screenshot 2025-12-15 at 14 38 38" src="https://github.com/user-attachments/assets/eff2ba77-ddd8-42ce-b238-ec078400ab4a" />
