### PR TITLE
feat(versions): Override version box jinja template

### DIFF
--- a/assets/js/components/record_details/RecordVersionItem.js
+++ b/assets/js/components/record_details/RecordVersionItem.js
@@ -1,0 +1,58 @@
+import React from "react";
+import { List } from "semantic-ui-react";
+import { i18next } from "@translations/invenio_app_rdm/i18next";
+import PropTypes from "prop-types";
+import { CopyButton } from "@js/invenio_app_rdm/components/CopyButton";
+
+export const RecordVersionItemContent = ({ item, activeVersion, doi }) => {
+  return (
+    <List.Item
+      key={item.id}
+      {...(activeVersion && { className: "version active" })}
+    >
+      <List.Content floated="left">
+        {activeVersion ? (
+          <span className="text-break">
+            {i18next.t("Version {{- version}}", { version: item.version })}
+          </span>
+        ) : (
+          <a href={`/records/${item.id}`} className="text-break">
+            {i18next.t("Version {{- version}}", { version: item.version })}
+          </a>
+        )}
+
+        {doi && (
+          <a
+            href={`https://doi.org/${doi}`}
+            className={
+              "doi" + (activeVersion ? " text-muted-darken" : " text-muted")
+            }
+          >
+            {doi}
+          </a>
+        )}
+      </List.Content>
+
+      <List.Content floated="right">
+        <CopyButton
+          text={item.links.self_html}
+          size="tiny"
+          className="cds-version mr-0"
+          icon="linkify"
+        />
+      </List.Content>
+
+      <List.Content floated="right">
+        <small className={activeVersion ? "text-muted-darken" : "text-muted"}>
+          {item.publication_date}
+        </small>
+      </List.Content>
+    </List.Item>
+  );
+};
+
+RecordVersionItemContent.propTypes = {
+  item: PropTypes.object.isRequired,
+  activeVersion: PropTypes.bool.isRequired,
+  doi: PropTypes.string.isRequired,
+};

--- a/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -16,6 +16,7 @@ import {
   SubmitReviewModalComponent,
 } from "../../components/deposit/overrides/PublishModal";
 import { LockRequestComponent } from "../../components/requests/overrides/LockRequest";
+import { RecordVersionItemContent } from "../../components/record_details/RecordVersionItem";
 
 export const overriddenComponents = {
   "InvenioAppRdm.RecordsList.layout": CDSRecordsList,
@@ -33,4 +34,5 @@ export const overriddenComponents = {
   "InvenioRdmRecords.SubmitReviewModal.container": SubmitReviewModalComponent,
   "InvenioRdmRecords.PublishModal.container": PublishModalComponent,
   "InvenioRequests.LockRequest": LockRequestComponent,
+  "InvenioAppRdm.RecordVersionsList.Item.container": RecordVersionItemContent,
 };

--- a/assets/less/cds-rdm/elements/button.overrides
+++ b/assets/less/cds-rdm/elements/button.overrides
@@ -3,3 +3,8 @@
     color: inherit;
   }
 }
+
+.cds-version.button {
+  margin-top: -0.4em;
+  margin-bottom: -0.4em;
+}

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -611,3 +611,18 @@ APP_RDM_RECORD_EXPORTERS = dict(sorted(_RECORD_EXPORTERS.items()))
 ADMINISTRATION_BASE_TEMPLATE = "cds_rdm/administration/admin_base_template.html"
 LOGGING_CONSOLE_LEVEL = "INFO"
 JOBS_LOGGING_LEVEL = "INFO"
+
+APP_RDM_DETAIL_SIDE_BAR_TEMPLATES = [
+    "invenio_app_rdm/records/details/side_bar/manage_menu.html",
+    "invenio_app_rdm/records/details/side_bar/metrics.html",
+    "cds_rdm/records/versions.html",
+    "invenio_app_rdm/records/details/side_bar/external_resources.html",
+    "invenio_app_rdm/records/details/side_bar/communities.html",
+    "invenio_app_rdm/records/details/side_bar/keywords_subjects.html",
+    "invenio_app_rdm/records/details/side_bar/details.html",
+    "invenio_app_rdm/records/details/side_bar/locations.html",
+    "invenio_app_rdm/records/details/side_bar/licenses.html",
+    "invenio_app_rdm/records/details/side_bar/citations.html",
+    "invenio_app_rdm/records/details/side_bar/export.html",
+    "invenio_app_rdm/records/details/side_bar/technical_metadata.html",
+]

--- a/site/cds_rdm/assets/semantic-ui/js/cds_rdm/record_details/CopyLatestVersionButton.js
+++ b/site/cds_rdm/assets/semantic-ui/js/cds_rdm/record_details/CopyLatestVersionButton.js
@@ -1,0 +1,31 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { i18next } from "@translations/invenio_app_rdm/i18next";
+import ReactDOM from "react-dom";
+import { CopyButton } from "@js/invenio_app_rdm/components/CopyButton";
+
+export const CopyLatestVersionButton = ({ text }) => {
+  return (
+    <CopyButton
+      basic
+      className="pt-10 pb-10 mr-0"
+      size="tiny"
+      icon="linkify"
+      labelPosition="right"
+      content={i18next.t("Copy latest version link")}
+      text={text}
+    />
+  );
+}
+
+CopyLatestVersionButton.propTypes = {
+  text: PropTypes.string.isRequired,
+};
+
+const domContainer = document.getElementById("copy-latest-version-button");
+const text = JSON.parse(domContainer.dataset.text);
+
+ReactDOM.render(
+  <CopyLatestVersionButton text={text} />,
+  domContainer
+);

--- a/site/cds_rdm/templates/semantic-ui/cds_rdm/records/versions.html
+++ b/site/cds_rdm/templates/semantic-ui/cds_rdm/records/versions.html
@@ -1,0 +1,30 @@
+{#
+  Copyright (C) 2026 CERN.
+
+  CDS-RDM is free software; you can redistribute it and/or modify it
+  it under the terms of the MIT License; see LICENSE file for more details.
+-#}
+
+<div class="sidebar-container">
+  <div class="ui medium top attached header mt-0 flex justify-space-between align-items-center">
+    <h3 class="mb-0">{{ _('Versions') }}</h3>
+    <div id="copy-latest-version-button" class="mr-0 flex" data-text='{{ record_ui["links"]["parent_html"] | tojson | safe }}'></div>
+  </div>
+  <div id="record-versions" class="ui segment rdm-sidebar bottom attached row pl-0 pr-0 pt-0">
+    <div class="versions">
+      <div id="recordVersions" data-record='{{ record_ui | tojson }}' data-preview='{{ is_preview | tojson }}'>
+        <div class="rel-p-1"></div>
+        <div class="ui fluid placeholder rel-mr-1 rel-ml-1"></div>
+        <div class="header">
+          <div class="line"></div>
+          <div class="line"></div>
+          <div class="line"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% block javascript %}
+  {{ webpack['copy_latest_version_button.js'] }}
+{% endblock %}

--- a/site/cds_rdm/webpack.py
+++ b/site/cds_rdm/webpack.py
@@ -18,6 +18,7 @@ theme = WebpackThemeBundle(
             entry={
                 "gltf_previewer_js": "./js/cds_rdm/previewers/gltf-previewer.js",
                 "gltf_previewer_css": "./less/cds_rdm/previewers/gltf-previewer.less",
+                "copy_latest_version_button": "./js/cds_rdm/record_details/CopyLatestVersionButton.js",
             },
             dependencies={
                 "three": "^0.182.0",


### PR DESCRIPTION
closes: #671 
  * Add "Copy latest version link" button with the "Versions" header
  * Override VersionsList to add copy button for each version

<img width="527" height="390" alt="image" src="https://github.com/user-attachments/assets/651675c8-6368-48a1-94e6-de85263dba18" />
