### PR TITLE
chore: upgrade locked dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,14 @@ dependencies = [
 cds-rdm = { workspace = true }
 invenio-cern-sync = { git = "https://github.com/cerndocumentserver/invenio-cern-sync", rev = "v0.5.0"}
 
+[tool.uv]
+override-dependencies = [
+    # The old version of invenio-files-rest we are using (before we upgrade to invenio-app-rdm 14.0.0b5.*) depends on `fs`
+    # which is unmaintained and depends on `setuptools`. A new major version of `setuptools` (81/82) is allowed by
+    # `fs` despite breaking it completely. For now, we are adding a dependency override to the last known working version.
+    "setuptools>=80.0.0,<81.0.0"
+]
+
 [tool.uv.workspace]
 members = [
     "site",

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ members = [
     "cds-rdm",
     "cds-rdm-app",
 ]
+overrides = [{ name = "setuptools", specifier = ">=80.0.0,<81.0.0" }]
 
 [[package]]
 name = "aiobotocore"
@@ -6919,11 +6920,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.0"
+version = "80.10.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/f3/748f4d6f65d1756b9ae577f329c951cda23fb900e4de9f70900ced962085/setuptools-82.0.0.tar.gz", hash = "sha256:22e0a2d69474c6ae4feb01951cb69d515ed23728cf96d05513d36e42b62b37cb", size = 1144893, upload-time = "2026-02-08T15:08:40.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl", hash = "sha256:70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0", size = 1003468, upload-time = "2026-02-08T15:08:38.723Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This includes `invenio-requests` release [v11.3.1](https://github.com/inveniosoftware/invenio-requests/commit/216e896d2c60c3ef89e76d16d2aaf53c2858f357) which fixes https://github.com/inveniosoftware/invenio-requests/issues/569