### PR TITLE
Permissions: create separate Archiver read all, notification roles

### DIFF
--- a/site/cds_rdm/permissions.py
+++ b/site/cds_rdm/permissions.py
@@ -23,7 +23,8 @@ from invenio_records_permissions.generators import SystemProcess
 from invenio_users_resources.services.permissions import UserManager
 
 from .generators import (
-    Archiver,
+    ArchiverNotification,
+    ArchiverRead,
     AuthenticatedRegularUser,
     CERNEmailsGroups,
     Librarian,
@@ -65,19 +66,19 @@ class CDSRDMRecordPermissionPolicy(RDMRecordPermissionPolicy):
     """Record permission policy."""
 
     can_create = [AuthenticatedRegularUser(), SystemProcess()]
-    can_read = RDMRecordPermissionPolicy.can_read + [Archiver()]
-    can_search = RDMRecordPermissionPolicy.can_search + [Archiver()]
-    can_read_files = RDMRecordPermissionPolicy.can_read_files + [Archiver()]
+    can_read = RDMRecordPermissionPolicy.can_read + [ArchiverRead()]
+    can_search = RDMRecordPermissionPolicy.can_search + [ArchiverRead()]
+    can_read_files = RDMRecordPermissionPolicy.can_read_files + [ArchiverRead()]
     can_get_content_files = RDMRecordPermissionPolicy.can_get_content_files + [
-        Archiver()
+        ArchiverRead()
     ]
     can_media_get_content_files = RDMRecordPermissionPolicy.can_get_content_files + [
-        Archiver()
+        ArchiverRead()
     ]
     can_read_deleted = [
         IfRecordDeleted(
             then_=[UserManager, SystemProcess()],
-            else_=can_read + [Archiver()],
+            else_=can_read + [ArchiverRead()],
         )
     ]
 
@@ -92,8 +93,8 @@ class CDSRDMRecordPermissionPolicy(RDMRecordPermissionPolicy):
 class CDSRDMPreservationSyncPermissionPolicy(DefaultPreservationInfoPermissionPolicy):
     """PreservationSync permission policy."""
 
-    can_read = RDMRecordPermissionPolicy.can_read + [Archiver()]
-    can_create = [Archiver()]
+    can_read = RDMRecordPermissionPolicy.can_read + [ArchiverNotification()]
+    can_create = [ArchiverNotification()]
 
 
 class CDSRequestsPermissionPolicy(RDMRequestsPermissionPolicy):

--- a/site/tests/conftest.py
+++ b/site/tests/conftest.py
@@ -541,7 +541,7 @@ def archiver(UserFixture, app, db):
         confirmed=True,
     )
     user_obj = user.create(app, db)
-    r = ds.create_role(name="oais-archiver", description="1234")
+    r = ds.create_role(name="archiver-read-all", description="1234")
     ds.add_role_to_user(user.user, r)
 
     return user


### PR DESCRIPTION
The goal is that the Preserve Platform dev and QA instance can use the Notification role and only for production it will obtain an API key with read all permission.