### PR TITLE
header: keep login buttons for mobile/tablet view

### DIFF
--- a/assets/less/cds-rdm/elements/container.overrides
+++ b/assets/less/cds-rdm/elements/container.overrides
@@ -45,6 +45,10 @@
   z-index: 4 !important;
 }
 
+.item.cds-login {
+    right: 2rem;
+}
+
 .cern-logo{
   display: flex;
   align-items: center;

--- a/templates/semantic-ui/invenio_app_rdm/header.html
+++ b/templates/semantic-ui/invenio_app_rdm/header.html
@@ -52,6 +52,12 @@
                     {%- endblock brand %}
                   {%- endblock navbar_header %}
                 </div>
+                
+                {%- if not current_user.is_authenticated %}
+                <div class="right item cds-login mobile tablet only">
+                  {%- include config.THEME_HEADER_LOGIN_TEMPLATE %}
+                </div>
+                {%- endif %}
 
                 <div id="rdm-burger-toggle">
                   <button


### PR DESCRIPTION
Login button is `hidden` in the burger-menu for tablet and mobile views

<img width="551" height="389" alt="Screenshot 2026-02-26 at 17 18 51" src="https://github.com/user-attachments/assets/084a04ab-a6da-46d3-89f8-ab30bf68617c" />

And if user is using this view it can be confusing to understand if they're logged in. 

This PR adds login buttons for tablet and mobile views

<img width="526" height="262" alt="Screenshot 2026-02-26 at 17 21 03" src="https://github.com/user-attachments/assets/b883ec79-a5ee-4104-8989-6927381a21a1" />
