### PR TITLE
fix: include alternate identifiers in linked records reverse lookup

### DIFF
--- a/site/cds_rdm/views.py
+++ b/site/cds_rdm/views.py
@@ -71,7 +71,8 @@ def get_linked_records_search_query(record):
     1. Records that this record references in related_identifiers (scheme="cds")
        - For legacy numeric recids: searches both id and metadata.identifiers
        - For new alphanumeric PIDs: searches only id
-    2. Records that reference this record in their related_identifiers (scheme="cds")
+    2. Records that reference this record in their related_identifiers
+       using either this record's internal id or any alternate identifiers.
 
     This handles CDS migration where old numeric recids are stored in
     metadata.identifiers.identifier when records get new PIDs.
@@ -104,12 +105,43 @@ def get_linked_records_search_query(record):
             query_parts.append(f'id:"{cds_id}"')
 
     # Part 2: Records that reference this record (reverse)
-    # Find records that have this record's CDS PIDs in their related_identifiers
-    record_id = record.data.get("id")
-    query_parts.append(
-        "(metadata.related_identifiers.scheme:cds AND "
-        f'metadata.related_identifiers.identifier:"{record_id}")'
+    # Find records that reference this record either by its internal CDS id
+    # or by any of its alternate identifiers.
+    record_id = record.data["id"]
+    linked_identifiers = {("cds", record_id)}
+
+    # Add alternate identifiers of the current record for reverse lookup
+    for ident in record.data.get("metadata", {}).get("identifiers", []):
+        scheme = ident.get("scheme")
+        identifier = ident.get("identifier")
+        if scheme and identifier:
+            linked_identifiers.add((scheme, identifier))
+
+    # Add record DOI of the current record for reverse lookup
+    version_doi = (
+        record.data.get("pids", {})
+        .get("doi", {})
+        .get("identifier")
     )
+    if version_doi:
+        linked_identifiers.add(("doi", version_doi))
+
+    # Add parent DOI of the current record for reverse lookup
+    parent_doi = (
+        record.data.get("parent", {})
+        .get("pids", {})
+        .get("doi", {})
+        .get("identifier")
+    )
+    if parent_doi:
+        linked_identifiers.add(("doi", parent_doi))
+
+    # Build reverse lookup query i.e search records that their related_identifiers reference this record's identifiers
+    for scheme, identifier in sorted(linked_identifiers):
+        query_parts.append(
+            f'(metadata.related_identifiers.scheme:{scheme} AND '
+            f'metadata.related_identifiers.identifier:"{identifier}")'
+        )
 
     if not query_parts:
         return None

--- a/site/tests/test_views.py
+++ b/site/tests/test_views.py
@@ -259,3 +259,22 @@ class TestGetLinkedRecordsSearchQuery:
         assert 'metadata.identifiers.identifier:"123abc"' not in query
         assert 'id:"abc123"' in query
         assert 'id:"123abc"' in query
+
+
+    def test_with_non_cds_identifiers(self):
+        """Test that non-CDS identifiers are ignored."""
+        record = MockRecord({
+            "id": "abc12-def34",
+            "metadata": {
+                "identifiers": [
+                    {"scheme": "cds", "identifier": "11111"},
+                    {"scheme": "cds", "identifier": "22222"},
+                ]
+            }
+        })
+
+        query = get_linked_records_search_query(record)
+
+        assert 'metadata.related_identifiers.scheme:cds AND metadata.related_identifiers.identifier:"abc12-def34"' in query
+        assert 'metadata.related_identifiers.scheme:cds AND metadata.related_identifiers.identifier:"11111"' in query
+        assert 'metadata.related_identifiers.scheme:cds AND metadata.related_identifiers.identifier:"22222"' in query


### PR DESCRIPTION
Fix linked records lookup when CDS identifier is stored as an alternate identifier.

During CDS migration, some legacy CDS record identifiers are preserved in metadata.identifiers while the record itself receives a new alphanumeric PID. The previous implementation only searched by record id, which caused linked records not to appear when the CDS identifier existed only in alternate identifiers.

This change extends the lookup query to also match identifiers stored in metadata.identifiers (scheme: cds).

Screenshots showing the issue and the expected behaviour are attached.
<img width="1154" height="186" alt="image" src="https://github.com/user-attachments/assets/c6cd4add-480f-476e-974e-27176b365f1c" />

<img width="1134" height="1126" alt="image" src="https://github.com/user-attachments/assets/1d8260c9-c4d5-454b-befc-ded5fe1a294a" />


Closes #730 