### PR TITLE
feat: require DOI for dissertations metadata check

### DIFF
--- a/scripts/metadata_checks.py
+++ b/scripts/metadata_checks.py
@@ -52,6 +52,31 @@ CERN_RESEARCH_RULES = {
             ],
         },
         {
+            "id": "cern:dissertation/doi-required",
+            "title": "Dissertation DOI required",
+            "message": "Dissertations must provide a DOI",
+            "description": "To submit a dissertation, a DOI must be provided.",
+            "level": "error",
+            "error_path": "pids.doi",
+            "condition": {
+                "type": "comparison",
+                "left": {"type": "field", "path": "metadata.resource_type.id"},
+                "operator": "==",
+                "right": "publication-dissertation",
+            },
+            "checks": [
+                {
+                    "type": "comparison",
+                    "left": {
+                        "type": "field",
+                        "path": "pids.doi.identifier",
+                    },
+                    "operator": "!=",
+                    "right": "",
+                }
+            ],
+        },
+        {
             "id": "cern:doi/prefix-community",
             "title": "CERN DOI prefix required",
             "message": "Records with publisher CERN must use the CERN DOI prefix.",


### PR DESCRIPTION
Part of https://github.com/CERNDocumentServer/cds-rdm/issues/586

This PR adds a metadata check to require a DOI for dissertation records.

A new rule was added to scripts/metadata_checks.py so that when the resource type is publication-dissertation, the metadata check validates that pids.doi.identifier is not empty.


## Recipe:


After web deployment — `metadata_checks`
  - Run the metadata-checks script to register the new metadata check that requires a DOI for dissertation records (`publication-dissertation`) on the CERN Scientific community:

    ```bash
    invenio shell scripts/metadata_checks.py
    ```


<img width="2502" height="887" alt="image" src="https://github.com/user-attachments/assets/ca2d5f30-5e39-479d-ba86-5a9158a8c642" />

