### PR TITLE
fix(harvester): align INSPIRE related identifier resource types

### DIFF
--- a/site/cds_rdm/inspire_harvester/transform/mappers/identifiers.py
+++ b/site/cds_rdm/inspire_harvester/transform/mappers/identifiers.py
@@ -204,7 +204,7 @@ class RelatedIdentifiersMapper(MapperBase):
                     "scheme": "inspire",
                     "identifier": ctx.inspire_id,
                     "relation_type": {"id": "isvariantformof"},
-                    "resource_type": {"id": "publication-other"},
+                    "resource_type": {"id": ctx.resource_type.value},
                 }
             )
 

--- a/site/tests/inspire_harvester/conftest.py
+++ b/site/tests/inspire_harvester/conftest.py
@@ -62,7 +62,7 @@ def transformed_record_no_files():
                     "identifier": "1695540",
                     "scheme": "inspire",
                     "relation_type": {"id": "isversionof"},
-                    "resource_type": {"id": "publication-other"},
+                    "resource_type": {"id": "publication-dissertation"},
                 }
             ],
         },

--- a/site/tests/inspire_harvester/test_harvester_job.py
+++ b/site/tests/inspire_harvester/test_harvester_job.py
@@ -93,10 +93,10 @@ expected_result_1 = {
                     },
                 },
                 "resource_type": {
-                    "id": "publication-other",
+                    "id": "publication-dissertation",
                     "title": {
                         "de": "Abschlussarbeit",
-                        "en": "Other",
+                        "en": "Thesis",
                     },
                 },
                 "scheme": "inspire",
@@ -196,10 +196,10 @@ expected_result_2 = {
                     },
                 },
                 "resource_type": {
-                    "id": "publication-other",
+                    "id": "publication-dissertation",
                     "title": {
                         "de": "Abschlussarbeit",
-                        "en": "Other",
+                        "en": "Thesis",
                     },
                 },
                 "scheme": "inspire",
@@ -275,10 +275,10 @@ expected_result_3 = {
                     },
                 },
                 "resource_type": {
-                    "id": "publication-other",
+                    "id": "publication-dissertation",
                     "title": {
                         "de": "Abschlussarbeit",
-                        "en": "Other",
+                        "en": "Thesis",
                     },
                 },
                 "scheme": "inspire",

--- a/site/tests/inspire_harvester/test_transformer.py
+++ b/site/tests/inspire_harvester/test_transformer.py
@@ -74,7 +74,7 @@ def test_transform_related_identifiers(mock_normalize_isbn, running_app):
         "identifier": "12345",
         "scheme": "inspire",
         "relation_type": {"id": "isvariantformof"},
-        "resource_type": {"id": "publication-other"},
+        "resource_type": {"id": "other"},
     } in result
     assert {
         "identifier": "978-0-123456-78-9",

--- a/site/tests/inspire_harvester/test_update_create_logic.py
+++ b/site/tests/inspire_harvester/test_update_create_logic.py
@@ -49,13 +49,7 @@ def test_new_non_CDS_record(
                     "en": "is variant of",
                 },
             },
-            "resource_type": {
-                "id": "publication-other",
-                "title": {
-                    "de": "Abschlussarbeit",
-                    "en": "Other",
-                },
-            },
+            "resource_type": created_record["metadata"]["resource_type"],
         }
     ]
     assert created_record["metadata"]["identifiers"] == [
@@ -147,7 +141,7 @@ def test_update_record_with_CDS_DOI_one_doc_type(
         "identifier": "2707794",
         "scheme": "inspire",
         "relation_type": {"id": "isvariantformof"},
-        "resource_type": {"id": "publication-other"},
+        "resource_type": {"id": "publication-preprint"},
     } in new_version.data["metadata"]["related_identifiers"]
 
     # clean up for other tests

--- a/site/tests/inspire_harvester/test_writer.py
+++ b/site/tests/inspire_harvester/test_writer.py
@@ -44,7 +44,7 @@ def transformed_record_1_file(scope="function"):
                     "identifier": "2685275",
                     "scheme": "inspire",
                     "relation_type": {"id": "isversionof"},
-                    "resource_type": {"id": "publication-other"},
+                    "resource_type": {"id": "publication-dissertation"},
                 }
             ],
         },
@@ -85,7 +85,7 @@ def transformed_record_2_files():
                     "identifier": "2685275",
                     "scheme": "inspire",
                     "relation_type": {"id": "isversionof"},
-                    "resource_type": {"id": "publication-other"},
+                    "resource_type": {"id": "publication-dissertation"},
                 }
             ],
         },
@@ -208,7 +208,7 @@ def test_writer_2_records(
                     "identifier": "1793973",
                     "scheme": "inspire",
                     "relation_type": {"id": "isversionof"},
-                    "resource_type": {"id": "publication-other"},
+                    "resource_type": {"id": "publication-dissertation"},
                 }
             ],
         },


### PR DESCRIPTION
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/727
Related pr https://gitlab.cern.ch/cds-team/production_scripts/-/merge_requests/47
This PR updates INSPIRE related identifier mapping so metadata.related_identifiers[].resource_type.id matches the record’s detected resource type (ctx.resource_type.value) instead of always being hardcoded to publication-other.

Updated affected INSPIRE harvester tests and fixtures to reflect the new expected mapping behavior; updated test set passes.