### PR TITLE
fix: use harvester admin action for audit log access

### DIFF
--- a/site/cds_rdm/generators.py
+++ b/site/cds_rdm/generators.py
@@ -15,9 +15,10 @@ from invenio_access.permissions import Permission
 from invenio_records_permissions.generators import AuthenticatedUser, Generator
 from invenio_search.engine import dsl
 
+from .administration.permissions import harvester_admin_access_action
+
 archiver_read_all_role = RoleNeed("archiver-read-all")
 archiver_notification_role = RoleNeed("archiver-notification")
-harvester_curator_role = RoleNeed("harvester-curator")
 
 clc_sync_action = action_factory("clc-sync")
 clc_sync_permission = Permission(clc_sync_action)
@@ -109,16 +110,16 @@ class ArchiverNotification(ArchiverRole):
 
 
 class HarvesterCurator(Generator):
-    """Allows harvester-curator role."""
+    """Allows harvester curators via the harvester admin action."""
 
     def needs(self, **kwargs):
         """Enabling Needs."""
-        return [harvester_curator_role]
+        return [harvester_admin_access_action]
 
     def query_filter(self, identity=None, **kwargs):
-        """Restrict harvester-curator to system user audit logs only."""
+        """Restrict harvester curators to system user audit logs only."""
         for need in identity.provides:
-            if need == harvester_curator_role:
+            if need == harvester_admin_access_action:
                 return dsl.Q("term", **{"user.id": "system"})
         return []
 

--- a/site/tests/test_permissions.py
+++ b/site/tests/test_permissions.py
@@ -6,10 +6,15 @@
 # the terms of the GPL-2.0 License; see LICENSE file for more details.
 
 """Permissions tests."""
+from types import SimpleNamespace
+
 import pytest
 from invenio_rdm_records.proxies import current_rdm_records
 from invenio_rdm_records.records.api import RDMDraft, RDMParent, RDMRecord
 from invenio_records_resources.services.errors import PermissionDeniedError
+
+from cds_rdm.administration.permissions import harvester_admin_access_action
+from cds_rdm.generators import HarvesterCurator
 
 
 def test_archiver_permissions(
@@ -34,3 +39,24 @@ def test_archiver_permissions(
     results = service.search(archiver.identity)
     assert results.total == 1
     assert results.to_dict()["hits"]["hits"][0]["id"] == recid
+
+
+@pytest.mark.parametrize(
+    ("provides", "expected_filter"),
+    [
+        ({harvester_admin_access_action}, {"term": {"user.id": "system"}}),
+        (set(), []),
+    ],
+)
+def test_harvester_curator_permissions(provides, expected_filter):
+    """Harvester permissions use the action need and filter system logs only."""
+    assert HarvesterCurator().needs() == [harvester_admin_access_action]
+
+    identity = SimpleNamespace(provides=provides)
+
+    query_filter = HarvesterCurator().query_filter(identity=identity)
+
+    if expected_filter:
+        assert query_filter.to_dict() == expected_filter
+    else:
+        assert query_filter == []


### PR DESCRIPTION
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/766 https://github.com/CERNDocumentServer/cds-rdm/issues/768

This pr fixes Harvester Reports and Download Harvester Logs in sandbox by switching the audit-log permission check from the hardcoded harvester-curator role to harvester-admin-access-action. While debugging, I confirmed sandbox users were being assigned cds-curators and that role already had the relevant harvester permissions, but the backend audit-log search path was still checking for a different thing, which caused the internal server error / PermissionDeniedError: search. This change aligns the code with the existing sandbox role/action setup so curator users can fetch, view, and download harvester logs as intended.