### PR TITLE
fix(dev): remove OpenSearch disk limit when running locally

### DIFF
--- a/docker-services.yml
+++ b/docker-services.yml
@@ -65,6 +65,7 @@ services:
     environment:
       # settings only for development. DO NOT use in production!
       - bootstrap.memory_lock=true
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx1024m"
       - "DISABLE_INSTALL_DEMO_CONFIG=true"
       - "DISABLE_SECURITY_PLUGIN=true"


### PR DESCRIPTION
* On my machine, OpenSearch allocates itself a finite amount of disk space, which can mean that once the indexes are filled up with the initial fixture vocabulary data, some errors start occurring about the storage being full.

* This config flag fixes this. It is only used on local dev instances, it never gets deployed anywhere, so it will not have a wider impact. It just helps to prevent some local bugs, at least for me

See https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/cluster-settings/#:~:text=cluster%2Erouting%2Eallocation%2Edisk%2Ethreshold%5Fenabled