### PR TITLE
fix(frontpage): align hero layout at 1280px viewport

### DIFF
--- a/assets/less/cds-rdm/globals/hero.less
+++ b/assets/less/cds-rdm/globals/hero.less
@@ -58,7 +58,9 @@
     position: relative;
     margin-left: auto;
     margin-right: auto;
-    @media all and (max-width: @computerBreakpoint) {
+    // Use @largestTabletScreen (1279px), not @computerBreakpoint (1280px), so
+    // desktop hex centering starts at exactly 1280px.
+    @media all and (max-width: @largestTabletScreen) {
       margin-left: unset;
       margin-right: unset;
     }
@@ -183,7 +185,7 @@
         top: 70%;
         left: 50%;
         .flat-text-shadow-mixin(@secondaryColor);
-        @media all and (max-width: @computerBreakpoint) {
+        @media all and (max-width: @largestTabletScreen) {
           top: 85%;
           left: 30%;
         }
@@ -194,7 +196,7 @@
         top: 25%;
         left: 45%;
         .flat-text-shadow-mixin(@tertiaryColor);
-        @media all and (max-width: @computerBreakpoint) {
+        @media all and (max-width: @largestTabletScreen) {
           left: 62%;
         }
       }
@@ -204,7 +206,7 @@
         top: 30%;
         left: 20%;
         .flat-text-shadow-mixin(@quinaryColor);
-        @media all and (max-width: @computerBreakpoint) {
+        @media all and (max-width: @largestTabletScreen) {
           top: 20%;
           left: 20%;
         }
@@ -215,7 +217,7 @@
         top: 80%;
         left: 25%;
         .flat-text-shadow-mixin(@CERNlightgray);
-        @media all and (max-width: @computerBreakpoint) {
+        @media all and (max-width: @largestTabletScreen) {
           top: 90%;
           left: 70%;
         }


### PR DESCRIPTION
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/755
 
This PR fixes the frontpage hero looking wrong at exactly 1280px screen width. In CDS, the “desktop” layout starts at 1280px, but some hero styles were still using the “tablet” layout at that width too so the background looked like desktop while the blue hex and icons were still positioned for tablet, which made the hero look broken. At 1279px and 1281px it looked fine and only 1280px was off. Reviewers can reproduce the issue by opening the frontpage in DevTools responsive mode and setting the width to 1280px. The fix updates five @media rules in hero.less to use @largestTabletScreen (1279px) instead, so desktop hero layout starts at 1280px and the behavior at all other widths is unchanged, and only the frontpage hero is affected.