### PR TITLE
fix(previewer): disable PDF.js streaming and range requests

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -674,6 +674,17 @@ PREVIEWER_PREFERENCE = DEFAULT_PREVIEWER_PREFERENCE + [
   "cds_rdm_gltf_previewer",
 ]
 
+PREVIEWER_PDF_JS_DOCUMENT_INIT_PARAMS = {
+    "disableStream": True,
+    "disableRange": True,
+    "disableAutoFetch": True,
+}
+"""PDF.js initialization parameters for document previewer.
+
+We disable range requests and streaming, to avoid overloading the server with
+multiple requests per PDF preview.
+"""
+
 PREVIEWER_MAX_IMAGE_SIZE_BYTES = 15 * (10**6)  # 15 MB
 """Maximum file size in bytes for image files."""
 


### PR DESCRIPTION
PDF previews were triggering duplicate network requests for the same file (the network tab showed the PDF being loaded twice). This adds PREVIEWER_PDF_JS_DOCUMENT_INIT_PARAMS to disable PDF.js streaming, range requests, and auto-fetch, so each preview loads the document in one request instead of multiple partial fetches against the server.