### PR TITLE
harvester: allow selecting document type per run

### DIFF
--- a/site/cds_rdm/inspire_harvester/jobs.py
+++ b/site/cds_rdm/inspire_harvester/jobs.py
@@ -12,7 +12,29 @@ from datetime import datetime
 from invenio_i18n import gettext as _
 from invenio_jobs.jobs import PredefinedArgsSchema
 from invenio_vocabularies.jobs import ProcessDataStreamJob
-from marshmallow import Schema, ValidationError, fields, validates_schema
+from marshmallow import (
+    ValidationError,
+    fields,
+    validate,
+    validates_schema,
+)
+
+from cds_rdm.inspire_harvester.transform.resource_types import (
+    ALL_DOCUMENT_TYPES,
+    INSPIRE_DOCUMENT_TYPE_MAPPING,
+)
+
+DOCUMENT_TYPE_CHOICES = (
+    ALL_DOCUMENT_TYPES,
+    *sorted(INSPIRE_DOCUMENT_TYPE_MAPPING),
+)
+DOCUMENT_TYPE_OPTIONS = [
+    {"id": ALL_DOCUMENT_TYPES, "title_l10n": _("All document types")},
+    *[
+        {"id": document_type, "title_l10n": _(document_type.title())}
+        for document_type in DOCUMENT_TYPE_CHOICES[1:]
+    ],
+]
 
 
 class InspireArgsSchema(PredefinedArgsSchema):
@@ -37,6 +59,19 @@ class InspireArgsSchema(PredefinedArgsSchema):
 
     inspire_id = fields.String(allow_none=True)
 
+    document_type = fields.String(
+        load_default=ALL_DOCUMENT_TYPES,
+        dump_default=ALL_DOCUMENT_TYPES,
+        validate=validate.OneOf(DOCUMENT_TYPE_CHOICES),
+        metadata={
+            "title": _("Document type"),
+            "description": _(
+                "Choose one INSPIRE document type to harvest, or choose all document types."
+            ),
+            "options": DOCUMENT_TYPE_OPTIONS,
+        },
+    )
+
     job_arg_schema = fields.String(
         metadata={"type": "hidden"},
         dump_default="InspireArgsSchema",
@@ -49,7 +84,12 @@ class InspireArgsSchema(PredefinedArgsSchema):
         since = data.get("since")
         until = data.get("until")
 
-        if since and until and since > until:
+        def _as_date(value):
+            if isinstance(value, datetime):
+                return value.date()
+            return value
+
+        if since and until and _as_date(since) > _as_date(until):
             error_message = (
                 f"Validation failed. The 'Since' date must be earlier than or equal to the 'Until' date. "
                 f"'Since' value: {since}, 'Until' value: {until}."
@@ -101,7 +141,14 @@ class ProcessInspireHarvesterJob(ProcessDataStreamJob):
 
     @classmethod
     def build_task_arguments(
-        cls, job_obj, since=None, inspire_id=None, until=None, on_date=None, **kwargs
+        cls,
+        job_obj,
+        since=None,
+        inspire_id=None,
+        until=None,
+        on_date=None,
+        document_type=ALL_DOCUMENT_TYPES,
+        **kwargs,
     ):
         """Build task arguments."""
         if isinstance(since, datetime):
@@ -111,6 +158,7 @@ class ProcessInspireHarvesterJob(ProcessDataStreamJob):
             "until": until.isoformat() if until else None,
             "on_date": on_date.isoformat() if on_date else None,
             "inspire_id": inspire_id,
+            "document_type": document_type,
         }
         # validate args
         InspireArgsSchema().load(data=reader_args)

--- a/site/cds_rdm/inspire_harvester/reader.py
+++ b/site/cds_rdm/inspire_harvester/reader.py
@@ -13,6 +13,10 @@ from flask import current_app
 from invenio_vocabularies.datastreams.errors import ReaderError
 from invenio_vocabularies.datastreams.readers import BaseReader
 
+from cds_rdm.inspire_harvester.transform.resource_types import (
+    ALL_DOCUMENT_TYPES,
+)
+
 
 class InspireHTTPReader(BaseReader):
     """INSPIRE HTTP Reader."""
@@ -25,6 +29,7 @@ class InspireHTTPReader(BaseReader):
         until=None,
         on_date=None,
         inspire_id=None,
+        document_type=ALL_DOCUMENT_TYPES,
         *args,
         **kwargs,
     ):
@@ -33,6 +38,7 @@ class InspireHTTPReader(BaseReader):
         self._until = until
         self._on_date = on_date
         self._inspire_id = inspire_id
+        self._document_type = document_type
 
         super().__init__(origin, mode, *args, **kwargs)
 
@@ -77,14 +83,20 @@ class InspireHTTPReader(BaseReader):
         """Builds a query depending on the input data."""
         current_app.logger.info("Start reading data from INSPIRE.")
 
-        # Fetch all document types marked for CDS via the OAI set
         oai_set = "ForCDS"
-        document_type = "thesis"
 
         q = f"_oai.sets:{oai_set}"
-        if document_type:
-            q += f" AND document_type:{document_type}"
+        if self._document_type and self._document_type != ALL_DOCUMENT_TYPES:
+            q += f' AND document_type:"{self._document_type}"'
 
+        document_type_scope = (
+            "all document types"
+            if not self._document_type or self._document_type == ALL_DOCUMENT_TYPES
+            else self._document_type
+        )
+        current_app.logger.info(
+            f"Harvesting INSPIRE scope: {document_type_scope}."
+        )
 
         if self._inspire_id:
             # get by INSPIRE id

--- a/site/cds_rdm/inspire_harvester/transform/resource_types.py
+++ b/site/cds_rdm/inspire_harvester/transform/resource_types.py
@@ -9,6 +9,8 @@
 
 from enum import Enum
 
+ALL_DOCUMENT_TYPES = "all"
+
 
 class ResourceType(str, Enum):
     """Enumeration of resource types for CDS-RDM."""


### PR DESCRIPTION
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/822

This adds a document type dropdown to the INSPIRE harvester job so a run can be limited to one selected document type or set to all document types. The selected value is passed into the harvester reader and used to build the INSPIRE query, while the rest of the harvester flow stays unchanged. I kept this scoped to run-time filtering so it can be merged first and remain compatible with cds-rdm#732.

<img width="1127" height="969" alt="image" src="https://github.com/user-attachments/assets/51e5ae51-1248-4186-9381-a870a94c5688" />
