### PR TITLE
Fix/dissertation doi metadata check

### DIFF
--- a/scripts/metadata_checks.py
+++ b/scripts/metadata_checks.py
@@ -52,31 +52,6 @@ CERN_RESEARCH_RULES = {
             ],
         },
         {
-            "id": "cern:dissertation/doi-required",
-            "title": "Dissertation DOI required",
-            "message": "Dissertations must provide a DOI",
-            "description": "To submit a dissertation, a DOI must be provided.",
-            "level": "error",
-            "error_path": "pids.doi",
-            "condition": {
-                "type": "comparison",
-                "left": {"type": "field", "path": "metadata.resource_type.id"},
-                "operator": "==",
-                "right": "publication-dissertation",
-            },
-            "checks": [
-                {
-                    "type": "comparison",
-                    "left": {
-                        "type": "field",
-                        "path": "pids.doi.identifier",
-                    },
-                    "operator": "!=",
-                    "right": "",
-                }
-            ],
-        },
-        {
             "id": "cern:doi/prefix-community",
             "title": "CERN DOI prefix required",
             "message": "Records with publisher CERN must use the CERN DOI prefix.",


### PR DESCRIPTION
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/586
Reverts the metadata check that required dissertation records to have a DOI.

