### PR TITLE
feat: add ATOM related identifier scheme

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -577,6 +577,11 @@ RDM_RECORDS_RELATED_IDENTIFIERS_SCHEMES = {
             "validator": schemes.is_edms,
             "datacite": "EDMS"
         },
+        "atom": {
+            "label": _("ATOM"),
+            "validator": schemes.is_atom,
+            "datacite": "ATOM",
+        },
         "hal": {
             "label": "HAL",
             "validator": schemes.is_hal,

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -726,6 +726,11 @@ RDM_RECORDS_RELATED_IDENTIFIERS_SCHEMES = {
             "validator": schemes.is_edms,
             "datacite": "EDMS"
         },
+        "archive": {
+            "label": _("ARCHIVE"),
+            "validator": schemes.is_archive,
+            "datacite": "ARCHIVE",
+        },
         "hal": {
             "label": "HAL",
             "validator": schemes.is_hal,

--- a/site/cds_rdm/schemes.py
+++ b/site/cds_rdm/schemes.py
@@ -27,6 +27,7 @@ hal_regexp = re.compile(r"^(hal:|HAL:)?((in2p3|[a-z]{3}[a-z]*)-|(sic|mem|ijn)_)\
 # Matches patterns like CERN-EP-2026-001 or CERN-TH-2026-042, as well as
 # legacy multi-segment department codes like CERN-PH-EP-2012-369.
 approval_rn_regexp = re.compile(r"^[A-Z]+(?:-[A-Z]+)*-\d{4}-\d+$")
+archive_pattern = re.compile(r"^CERN-ARCH(?:-[A-Z0-9]+)+$", flags=re.I)
 
 
 def is_aleph(val):
@@ -194,3 +195,8 @@ def hal():
         "normalizer": lambda value: value.lower(),
         "url_generator": generate_hal_url,
     }
+
+
+def is_archive(val):
+    """Test if argument is a CERN Archives reference code."""
+    return archive_pattern.match(str(val).strip())

--- a/site/cds_rdm/schemes.py
+++ b/site/cds_rdm/schemes.py
@@ -24,6 +24,12 @@ legacy_cds_pattern = re.compile(r"^\d+$", flags=re.I)
 is_indico_regexp = re.compile(r"^[a-zA-Z0-9]+$", flags=re.I)
 inis_pattern = re.compile(r"^(?:\d+|RN:\d+)$", flags=re.I)
 edms_pattern = re.compile(r"^\d+$", flags=re.I)
+atom_pattern = re.compile(r"^[a-z0-9][a-z0-9-]*$", flags=re.I)
+
+
+def is_atom(val):
+    """Test if argument matches an AtoM slug/permalink segment."""
+    return atom_pattern.match(str(val).strip())
 
 
 def is_aleph(val):

--- a/site/tests/conftest.py
+++ b/site/tests/conftest.py
@@ -268,6 +268,11 @@ def app_config(app_config, mock_datacite_client, mock_crossref_client):
             "validator": schemes.is_edms,
             "datacite": "EDMS",
         },
+        "archive": {
+            "label": _("ARCHIVE"),
+            "validator": schemes.is_archive,
+            "datacite": "ARCHIVE",
+        },
         "cdsrn": {
             "label": _("CDS Report Number"),
             "validator": always_valid,


### PR DESCRIPTION
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/786 
 
Adds ATOM as a CDS-specific related identifier scheme so it can be selected in the Related works section like the other CDS-only schemes. The change keeps the implementation consistent with the existing project pattern by registering the scheme in CDS config, adding the validator/normalizer in schemes.py, and updating the test config accordingly.