### PR TITLE
fix(ep): clarify wording in new version warning

### DIFF
--- a/assets/js/components/record_details/NewVersionButton.js
+++ b/assets/js/components/record_details/NewVersionButton.js
@@ -14,15 +14,19 @@ export const NewVersionButton = ({ onError, record, disabled, ...uiProps }) => {
   const [loading, setLoading] = useState(false);
   const [showModal, setShowModal] = useState(false);
 
-  const committeeApprovalData = useMemo(() => {
+  const committeeApprovalStatus = useMemo(() => {
     const recordManagementDiv = document.getElementById("recordManagement");
     return recordManagementDiv
       ? JSON.parse(recordManagementDiv.dataset.committeeApproval || "null")
+          ?.open_request?.status
       : null;
   }, []);
 
   const handleClick = useCallback(async () => {
-    if (!!committeeApprovalData?.open_request && !showModal) {
+    if (
+      ["submitted", "accepted"].includes(committeeApprovalStatus) &&
+      !showModal
+    ) {
       // If a request exists, we discourage creating a new version.
       // This applies even if the request has been accepted.
       setShowModal(true);
@@ -40,7 +44,7 @@ export const NewVersionButton = ({ onError, record, disabled, ...uiProps }) => {
       setLoading(false);
       onError(error.response.data.message);
     }
-  }, [committeeApprovalData, record, onError, showModal]);
+  }, [committeeApprovalStatus, record, onError, showModal]);
 
   return (
     <>
@@ -74,20 +78,35 @@ export const NewVersionButton = ({ onError, record, disabled, ...uiProps }) => {
       <Modal open={showModal} onClose={() => setShowModal(false)} size="small">
         <Modal.Header>
           <Icon name="warning sign" color="yellow" className="mr-10" />
-          {i18next.t("EP approval request pending")}
+
+          {committeeApprovalStatus === "submitted" &&
+            i18next.t("EP approval request pending")}
+          {committeeApprovalStatus === "accepted" &&
+            i18next.t("EP approval already complete")}
         </Modal.Header>
         <Modal.Content>
-          <p>
-            {i18next.t(
-              "An EP approval request is already pending for an existing version of this record. " +
-                "A new version will not be taken into account for the approval request."
-            )}
-          </p>
-          <p>
-            {i18next.t(
-              "Creating a new version while the request is pending is not recommended."
-            )}
-          </p>
+          {committeeApprovalStatus === "submitted" && (
+            <>
+              <p>
+                {i18next.t(
+                  "An EP approval request is already pending for an existing version of this record. " +
+                    "A new version will not be taken into account for the approval request."
+                )}
+              </p>
+              <p>
+                {i18next.t(
+                  "Creating a new version while the request is pending is not recommended."
+                )}
+              </p>
+            </>
+          )}
+          {committeeApprovalStatus === "accepted" && (
+            <p>
+              {i18next.t(
+                "A version of this record has already been approved. Creating a new version following an approved request is not recommended."
+              )}
+            </p>
+          )}
         </Modal.Content>
         <Modal.Actions>
           <Button onClick={() => setShowModal(false)}>


### PR DESCRIPTION
The warning is shown whenever a Committee Approval request exists for (any version of) the record, regardless of what status the request has. Even if it is accepted, the warning will still show. So I have changed the message slightly to avoid confusion for non-pending statuses.