### PR TITLE
Auto-reload record detail page after submitting EP request

### DIFF
--- a/assets/js/components/record_details/CommitteeApproval.js
+++ b/assets/js/components/record_details/CommitteeApproval.js
@@ -41,20 +41,6 @@ export class CommitteeApprovalManageSection extends Component {
     );
   }
 
-  handleSubmitSuccess = (request) => {
-    this.setState((prev) => ({
-      submitModalOpen: false,
-      committeeApproval: {
-        ...prev.committeeApproval,
-        open_request: {
-          id: request.id,
-          status: "submitted",
-          links: request.links,
-        },
-      },
-    }));
-  };
-
   handlePublicRecordCreated = (publicRecord) => {
     this.setState({
       publicRecordId: publicRecord.id,
@@ -229,7 +215,6 @@ export class CommitteeApprovalManageSection extends Component {
                 record={record}
                 receiverGroup={receiverGroup}
                 onClose={() => this.setState({ submitModalOpen: false })}
-                onSuccess={this.handleSubmitSuccess}
               />
             )}
           </Step>

--- a/assets/js/components/record_details/CommitteeApprovalSubmitModal.js
+++ b/assets/js/components/record_details/CommitteeApprovalSubmitModal.js
@@ -47,7 +47,7 @@ export class CommitteeApprovalSubmitModal extends Component {
   };
 
   handleSubmit = async () => {
-    const { record, receiverGroup, onSuccess } = this.props;
+    const { record, receiverGroup } = this.props;
     const { form } = this.state;
 
     this.setState({ submitting: true, error: null });
@@ -57,19 +57,16 @@ export class CommitteeApprovalSubmitModal extends Component {
         receiver_group: receiverGroup,
         payload: { ...form },
       };
-      const response = await http.post(
-        `/api/records/${record.id}/committee-approval`,
-        payload,
-        { headers: { "Content-Type": "application/json" } }
-      );
-      onSuccess(response.data);
+      await http.post(`/api/records/${record.id}/committee-approval`, payload, {
+        headers: { "Content-Type": "application/json" },
+      });
+
+      window.location.reload();
     } catch (err) {
       const msg =
         err?.response?.data?.message ||
         i18next.t("An error occurred. Please try again.");
-      this.setState({ error: msg });
-    } finally {
-      this.setState({ submitting: false });
+      this.setState({ error: msg, submitting: false });
     }
   };
 
@@ -212,7 +209,6 @@ CommitteeApprovalSubmitModal.propTypes = {
   record: PropTypes.object.isRequired,
   receiverGroup: PropTypes.string,
   onClose: PropTypes.func.isRequired,
-  onSuccess: PropTypes.func.isRequired,
 };
 
 CommitteeApprovalSubmitModal.defaultProps = {


### PR DESCRIPTION
**Please merge #848 first**

Closes #847 

---

The record detail page is now reloaded after the EP request is sucessfully submitted. The button remains in a loading state to clarify to the user that the page is reloading and that no action needs to be taken.