### PR TITLE
feat: genericise EP approval UI labels via config

### DIFF
--- a/assets/js/components/record_details/CommitteeApproval.js
+++ b/assets/js/components/record_details/CommitteeApproval.js
@@ -65,6 +65,7 @@ export class CommitteeApprovalManageSection extends Component {
     // Public EP-approved record — show a compact provenance note.
     if (committeeApproval.is_public_approved_record) {
       const {
+        approval_label: approvalLabel,
         approved_report_number: pubRn,
         draft_record_id: draftRecordId,
         can_view_reviewed_version: canViewReviewedVersion,
@@ -73,7 +74,11 @@ export class CommitteeApprovalManageSection extends Component {
       return (
         <Grid.Column className="pb-20 pt-0">
           <Divider horizontal>
-            <Header as="h4">{i18next.t("Approval request workflow")}</Header>
+            <Header as="h4">
+              {i18next.t("{{approvalLabel}} request workflow", {
+                approvalLabel,
+              })}
+            </Header>
           </Divider>
 
           <p className="text-muted text-align-center">
@@ -104,6 +109,8 @@ export class CommitteeApprovalManageSection extends Component {
     const {
       can_submit: canSubmit,
       can_create_public: canCreatePublicFlag,
+      approval_label: approvalLabel,
+      committee_name: committeeName,
       open_request: openRequest,
       approved_report_number: approvedReportNumber,
       receiver_group: receiverGroup,
@@ -151,7 +158,11 @@ export class CommitteeApprovalManageSection extends Component {
     return (
       <Grid.Column className="pb-20 pt-0">
         <Divider horizontal>
-          <Header as="h4">{i18next.t("Approval request workflow")}</Header>
+          <Header as="h4">
+            {i18next.t("{{approvalLabel}} request workflow", {
+              approvalLabel,
+            })}
+          </Header>
         </Divider>
 
         <Step.Group
@@ -191,7 +202,12 @@ export class CommitteeApprovalManageSection extends Component {
                     ) : step1Completed ? (
                       i18next.t("Request submitted.")
                     ) : (
-                      i18next.t("Submit the document for EP committee review.")
+                      i18next.t(
+                        "Submit the document for {{committeeName}} review.",
+                        {
+                          committeeName,
+                        }
+                      )
                     )}
                   </Step.Description>
                 </div>
@@ -228,7 +244,11 @@ export class CommitteeApprovalManageSection extends Component {
             <Step.Content>
               <div className="committee-action-step">
                 <div>
-                  <Step.Title>{i18next.t("EP Board review")}</Step.Title>
+                  <Step.Title>
+                    {i18next.t("{{committeeName}} review", {
+                      committeeName,
+                    })}
+                  </Step.Title>
                   <Step.Description>
                     {step2Completed ? (
                       requestLink ? (
@@ -245,7 +265,10 @@ export class CommitteeApprovalManageSection extends Component {
                       )
                     ) : (
                       i18next.t(
-                        "The EP secretariat will review the submission."
+                        "The {{committeeName}} will review the submission.",
+                        {
+                          committeeName,
+                        }
                       )
                     )}
                   </Step.Description>
@@ -295,9 +318,7 @@ export class CommitteeApprovalManageSection extends Component {
                         i18next.t("Public record created.")
                       )
                     ) : (
-                      i18next.t(
-                        "Publish the EP-approved record publicly on CDS."
-                      )
+                      i18next.t("Publish the approved record publicly on CDS.")
                     )}
                   </Step.Description>
                 </div>

--- a/assets/js/components/record_details/NewVersionButton.js
+++ b/assets/js/components/record_details/NewVersionButton.js
@@ -10,17 +10,21 @@ import { http } from "react-invenio-forms";
 import { Button, Icon, Modal, Popup } from "semantic-ui-react";
 import { i18next } from "@translations/invenio_rdm_records/i18next";
 
+const readCommitteeApprovalState = () => {
+  const recordManagementDiv = document.getElementById("recordManagement");
+  return recordManagementDiv
+    ? JSON.parse(recordManagementDiv.dataset.committeeApproval || "null")
+    : null;
+};
+
 export const NewVersionButton = ({ onError, record, disabled, ...uiProps }) => {
   const [loading, setLoading] = useState(false);
   const [showModal, setShowModal] = useState(false);
 
-  const committeeApprovalStatus = useMemo(() => {
-    const recordManagementDiv = document.getElementById("recordManagement");
-    return recordManagementDiv
-      ? JSON.parse(recordManagementDiv.dataset.committeeApproval || "null")
-          ?.open_request?.status
-      : null;
-  }, []);
+  const committeeApproval = useMemo(readCommitteeApprovalState, []);
+  const committeeApprovalStatus = committeeApproval?.open_request?.status;
+  const approvalLabel =
+    committeeApproval?.approval_label || i18next.t("Committee approval");
 
   const handleClick = useCallback(async () => {
     if (
@@ -80,17 +84,24 @@ export const NewVersionButton = ({ onError, record, disabled, ...uiProps }) => {
           <Icon name="warning sign" color="yellow" className="mr-10" />
 
           {committeeApprovalStatus === "submitted" &&
-            i18next.t("EP approval request pending")}
+            i18next.t("{{approvalLabel}} request pending", {
+              approvalLabel,
+            })}
           {committeeApprovalStatus === "accepted" &&
-            i18next.t("EP approval already complete")}
+            i18next.t("{{approvalLabel}} already complete", {
+              approvalLabel,
+            })}
         </Modal.Header>
         <Modal.Content>
           {committeeApprovalStatus === "submitted" && (
             <>
               <p>
                 {i18next.t(
-                  "An EP approval request is already pending for an existing version of this record. " +
-                    "A new version will not be taken into account for the approval request."
+                  "An {{approvalLabel}} request is already pending for an existing version of this record. " +
+                    "A new version will not be taken into account for the {{approvalLabel}} request.",
+                  {
+                    approvalLabel,
+                  }
                 )}
               </p>
               <p>

--- a/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
+++ b/assets/js/invenio_app_rdm/overridableRegistry/mapping.js
@@ -4,7 +4,10 @@
 // CDS RDM is free software; you can redistribute it and/or modify it
 // under the terms of the GPL-2.0 License; see LICENSE file for more details.
 
-import React from "react";
+import React, { useContext } from "react";
+import { DatasetContext } from "@js/invenio_requests/data";
+import { i18next as requestsI18next } from "@translations/invenio_requests/i18next";
+import { Label } from "semantic-ui-react";
 import { BasicCERNInformation } from "../../components/deposit/BasicInformation";
 import { CDSCarouselItem } from "../../components/communities_carousel/overrides/CarouselItem";
 import { CDSRecordsList } from "../../components/frontpage/overrides/RecordsList";
@@ -29,6 +32,17 @@ const RecordManagementContainer = (props) => (
   </>
 );
 
+const CommitteeApprovalRequestTypeLabel = () => {
+  const dataset = useContext(DatasetContext);
+  const approvalLabel = dataset?.request?.payload?.approval_label;
+
+  return (
+    <Label horizontal className="primary theme-secondary" size="small">
+      {approvalLabel || requestsI18next.t("Committee review")}
+    </Label>
+  );
+};
+
 export const overriddenComponents = {
   "InvenioAppRdm.RecordsList.layout": CDSRecordsList,
   "InvenioAppRdm.RecordsResultsListItem.layout": CDSRecordsResultsListItem,
@@ -48,6 +62,8 @@ export const overriddenComponents = {
   "InvenioRdmRecords.RecordLandingPage.RecordManagement.NewVersionButton":
     NewVersionButton,
   "InvenioRequests.LockRequest": LockRequestComponent,
+  "RequestTypeLabel.layout.committee-approval":
+    CommitteeApprovalRequestTypeLabel,
   "InvenioAppRdm.RecordVersionsList.Item.container": RecordVersionItemContent,
   "InvenioRequests.TimelineEventBody": TimelineEventBodyComponent,
 };

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -461,7 +461,8 @@ CDS_COMMITTEE_APPROVAL_COMMUNITIES = {
     # UUIDs are used (not slugs) because slugs can be renamed.
     #
     # "4b121eb9-3559-487d-9f73-8af1027668e9": {
-    #     "label": "EP approval",           # shown in UI buttons/headings
+    #     "label": "EP approval",           # shown in request buttons/headings
+    #     "committee_name": "EP Board",     # shown in review-step labels/text
     #     "referee_group": "cds-ph-ep-publication",  # CERN e-group slug
     #     "report_number": {
     #         "prefix": "CERN-EP",   # literal prefix, e.g. "CERN-EP"
@@ -473,7 +474,10 @@ CDS_COMMITTEE_APPROVAL_COMMUNITIES = {
 """Communities enrolled in the Publication Approval Workflow.
 
 Keyed by community UUID.  Each entry must have:
-  - ``label``: human-readable name shown in the UI (e.g. "EP approval")
+  - ``label``: human-readable workflow label shown in the UI
+    (e.g. "EP approval")
+  - ``committee_name`` (optional): reviewer/board name shown in review-step
+    labels and text (e.g. "EP Board")
   - ``referee_group``: CERN e-group whose members act as referees
   - ``report_number``: dict with:
       - ``prefix`` (str): fixed prefix, e.g. ``"CERN-EP"``

--- a/site/cds_rdm/requests/committee_approval.py
+++ b/site/cds_rdm/requests/committee_approval.py
@@ -343,6 +343,8 @@ class CommitteeApprovalRequest(RDMBaseRequest):
 
     # Payload fields collected from the submission form.
     payload_schema: Final[dict] = {
+        # Captured at submission for request-page and email display.
+        "approval_label": fields.Str(load_default=None),
         # Populated on accept by the system.
         "approved_report_number": fields.Str(load_default=None),
         # Form fields.

--- a/site/cds_rdm/requests/committee_approval_state.py
+++ b/site/cds_rdm/requests/committee_approval_state.py
@@ -15,6 +15,16 @@ from invenio_rdm_records.requests.record_deletion import current_rdm_records_ser
 from invenio_requests.proxies import current_requests_service
 
 
+def _approval_label(community_config=None):
+    """Return the UI label for this workflow."""
+    return (community_config or {}).get("label")
+
+
+def _committee_name(community_config=None):
+    """Return the configured reviewer/board name for this workflow."""
+    return (community_config or {}).get("committee_name")
+
+
 def _get_enrolled_community(record_ui):
     """Return (community_id, community_config) for enrolled communities, else (None, None)."""
     ep_communities = current_app.config.get("CDS_COMMITTEE_APPROVAL_COMMUNITIES", {})
@@ -139,6 +149,8 @@ def get_committee_approval_state(record_ui, record=None):
     Returns a dict with:
       - can_submit: bool
       - can_create_public: bool
+      - approval_label: str
+      - committee_name: str or None
       - community_enrolled: bool
       - is_public_approved_record: bool
       - open_request: dict or None — {id, status, links}
@@ -150,6 +162,7 @@ def get_committee_approval_state(record_ui, record=None):
     """
     # Read committee_approval from the parent.
     ea = _get_parent_committee_approval(record)
+    community_id, community_config = _get_enrolled_community(record_ui)
 
     # Early exit: this IS the public committee-approved copy.
     # The public record's parent has source_internal_version set.
@@ -167,6 +180,8 @@ def get_committee_approval_state(record_ui, record=None):
         return {
             "can_submit": False,
             "can_create_public": False,
+            "approval_label": _approval_label(community_config),
+            "committee_name": _committee_name(community_config),
             "community_enrolled": False,
             "is_public_approved_record": True,
             "open_request": None,
@@ -180,11 +195,12 @@ def get_committee_approval_state(record_ui, record=None):
         }
 
     # Check community enrollment.
-    community_id, community_config = _get_enrolled_community(record_ui)
     if community_id is None:
         return {
             "can_submit": False,
             "can_create_public": False,
+            "approval_label": _approval_label(),
+            "committee_name": None,
             "community_enrolled": False,
             "is_public_approved_record": False,
             "open_request": None,
@@ -217,6 +233,8 @@ def get_committee_approval_state(record_ui, record=None):
     return {
         "can_submit": can_submit,
         "can_create_public": can_create_public,
+        "approval_label": _approval_label(community_config),
+        "committee_name": _committee_name(community_config),
         "community_enrolled": True,
         "is_public_approved_record": False,
         "open_request": open_request,

--- a/site/cds_rdm/requests/views.py
+++ b/site/cds_rdm/requests/views.py
@@ -59,6 +59,16 @@ def create_committee_approval_bp(app):
             )
 
             title = record.data.get("metadata", {}).get("title", "")
+            default_community_id = (
+                record._record.parent.get("communities", {}) or {}
+            ).get("default")
+            approval_label = (
+                current_app.config.get("CDS_COMMITTEE_APPROVAL_COMMUNITIES", {})
+                .get(default_community_id, {})
+                .get("label")
+                or "Committee approval"
+            )
+            payload["approval_label"] = approval_label
             req = current_requests_service.create(
                 identity=g.identity,
                 data={

--- a/templates/semantic-ui/invenio_notifications/committee-approval-request.submit.jinja
+++ b/templates/semantic-ui/invenio_notifications/committee-approval-request.submit.jinja
@@ -2,7 +2,7 @@
 {% set record = committee_request.topic %}
 {% set request_id = committee_request.id %}
 {% set record_title = record.metadata.title %}
-{% set report_number = committee_request.title | replace('Committee approval for "', '') | replace('"', '') %}
+{% set approval_label = committee_request.payload.get("approval_label", "Committee approval") %}
 {% if recipient.data.profile is defined and recipient.data.profile.full_name %}
   {% set recipient_full_name = recipient.data.profile.full_name %}
 {% else %}
@@ -23,7 +23,7 @@
 %}
 
 {%- block subject -%}
-    [CDS] {{ _("Request for committee approval of '{record_title}'").format(record_title=record_title) }}
+    [CDS] {{ _("Request for {approval_label} of '{record_title}'").format(approval_label=approval_label, record_title=record_title) }}
 {%- endblock subject -%}
 
 {%- block html_body -%}
@@ -34,7 +34,7 @@
         </tr>
         <tr>
             <td>
-                {{ _("A new committee approval request has been submitted for the following document:") }}
+                {{ _("A new {approval_label} request has been submitted for the following document:").format(approval_label=approval_label) }}
             </td>
         </tr>
         <tr>
@@ -47,7 +47,7 @@
             <td>{{ _("Please review the document and register your decision at the link below.") }}</td>
         </tr>
         <tr>
-            <td><a href="{{ request_link }}">{{ _("Review the approval request") }}</a></td>
+            <td><a href="{{ request_link }}">{{ _("Review the {approval_label} request").format(approval_label=approval_label) }}</a></td>
         </tr>
         <tr>
             <td>
@@ -66,14 +66,14 @@
 {%- block plain_body -%}
 {{ _("Dear {recipient}").format(recipient=recipient_full_name) }},
 
-{{ _("A new committee approval request has been submitted for the following document:") }}
+{{ _("A new {approval_label} request has been submitted for the following document:").format(approval_label=approval_label) }}
 
 {{ _("Title:") }} {{ record_title }}
 {{ _("Record:") }} {{ record_link }}
 
 {{ _("Please review the document and register your decision at the link below.") }}
 
-{{ _("Review the approval request:") }} {{ request_link }}
+{{ _("Review the {approval_label} request:").format(approval_label=approval_label) }} {{ request_link }}
 
 {{ _("Best regards") }},
 --
@@ -86,14 +86,14 @@ CERN Document Server {{ config.SITE_UI_URL }}
 {%- block md_body -%}
 {{ _("Dear {recipient}").format(recipient=recipient_full_name) }},
 
-{{ _("A new committee approval request has been submitted for the following document:") }}
+{{ _("A new {approval_label} request has been submitted for the following document:").format(approval_label=approval_label) }}
 
 **{{ _("Title:") }}** {{ record_title }}
 **{{ _("Record:") }}** {{ record_link }}
 
 {{ _("Please review the document and register your decision at the link below.") }}
 
-{{ _("Review the approval request:") }} {{ request_link }}
+{{ _("Review the {approval_label} request:").format(approval_label=approval_label) }} {{ request_link }}
 
 {{ _("Best regards") }},
 --


### PR DESCRIPTION
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/843

This PR makes the EP approval UI labels configurable from CDS_COMMITTEE_APPROVAL_COMMUNITIES in invenio.cfg instead of hardcoding EP-specific wording everywhere. I used the existing label config for EP approval-style text, added optional committee_name support for review-step wording like EP Board review, and kept generic committee wording in places where direct substitution would be awkward. I also cleaned up the implementation so the workflow config is resolved through the shared helper and used consistently across the record page, request flow, and submit-notification email.