### PR TITLE
fix harvester conflict handling

### DIFF
--- a/site/cds_rdm/inspire_harvester/update/config.py
+++ b/site/cds_rdm/inspire_harvester/update/config.py
@@ -29,7 +29,7 @@ UPDATE_STRATEGY_CONFIG = {
     "metadata.contributors": CreatibutorsFieldUpdate(strict=False),
     "metadata.identifiers": IdentifiersFieldUpdate(),
     "metadata.related_identifiers": RelatedIdentifiersUpdate(),
-    "metadata.publication_date": PublicationDateUpdate(),
+    "metadata.publication_date": OverwriteFieldUpdate(),
     "metadata.subjects": ListOfDictAppendUniqueUpdate(key_field="subject"),
     "metadata.languages": ListOfDictAppendUniqueUpdate(key_field="id"),
     "metadata.description": OverwriteFieldUpdate(),
@@ -38,4 +38,10 @@ UPDATE_STRATEGY_CONFIG = {
     "custom_fields.cern:accelerators": ListOfDictAppendUniqueUpdate(key_field="id"),
     "custom_fields.cern:experiments": ListOfDictAppendUniqueUpdate(key_field="id"),
     # "custom_fields.cern:beams": IgnoreFieldUpdate(),
+}
+
+
+CDS_ORIGINAL_RECORD_UPDATE_STRATEGY_CONFIG = {
+    **UPDATE_STRATEGY_CONFIG,
+    "metadata.publication_date": PublicationDateUpdate(),
 }

--- a/site/cds_rdm/inspire_harvester/writer.py
+++ b/site/cds_rdm/inspire_harvester/writer.py
@@ -24,8 +24,15 @@ from cds_rdm.inspire_harvester.logger import (
     format_validation_error,
     hlog,
 )
-from cds_rdm.inspire_harvester.update.config import UPDATE_STRATEGY_CONFIG
-from cds_rdm.inspire_harvester.update.engine import UpdateContext, UpdateEngine
+from cds_rdm.inspire_harvester.update.config import (
+    CDS_ORIGINAL_RECORD_UPDATE_STRATEGY_CONFIG,
+    UPDATE_STRATEGY_CONFIG,
+)
+from cds_rdm.inspire_harvester.update.engine import (
+    UpdateContext,
+    UpdateEngine,
+    UpdateEngineConflict,
+)
 from cds_rdm.inspire_harvester.utils import compare_metadata
 from cds_rdm.utils import compact_text
 
@@ -61,6 +68,10 @@ class InspireWriter(BaseWriter):
 
         try:
             op_type = self._route(stream_entry)
+        except UpdateEngineConflict as e:
+            error_message = "Update conflict: {}".format(
+                "; ".join(str(conflict) for conflict in e.conflicts)
+            )
         except WriterError as e:
             error_message = compact_text(e)
         except ValidationError as e:
@@ -117,29 +128,25 @@ class InspireWriter(BaseWriter):
 
         has_cds_doi = record.data["pids"].get("doi", {}).get("provider") == "datacite"
 
+        strategies = (
+            CDS_ORIGINAL_RECORD_UPDATE_STRATEGY_CONFIG
+            if has_cds_doi
+            else UPDATE_STRATEGY_CONFIG
+        )
+        engine = UpdateEngine(strategies=strategies, fail_on_conflict=True)
+        result = engine.update(
+            record_dict, entry, UpdateContext(source="inspire_import"), logger
+        )
+        update_metadata = result.updated
+
         latest_res_type_changed = (
             record.data["metadata"]["resource_type"]["id"]
             != entry["metadata"]["resource_type"]["id"]
         )
 
         if should_update_files and has_cds_doi and latest_res_type_changed:
-            engine = UpdateEngine(
-                strategies=UPDATE_STRATEGY_CONFIG, fail_on_conflict=False
-            )
-            result = engine.update(
-                record_dict, entry, UpdateContext(source="inspire_import"), logger
-            )
-            update_metadata = result.updated
-
             self._resource_type_versioning(record, update_metadata, ctx, logger)
         else:
-            engine = UpdateEngine(
-                strategies=UPDATE_STRATEGY_CONFIG, fail_on_conflict=True
-            )
-            result = engine.update(
-                record_dict, entry, UpdateContext(source="inspire_import"), logger
-            )
-            update_metadata = result.updated
             is_pids_equal = update_metadata["pids"] == record_dict["pids"]
             is_metadata_equal = compare_metadata(
                 update_metadata["metadata"], record_dict["metadata"]

--- a/site/tests/inspire_harvester/test_writer.py
+++ b/site/tests/inspire_harvester/test_writer.py
@@ -362,6 +362,69 @@ def test_writer_1_existing_found_files_not_changed_metadata_changed(
     _cleanup_record(existing["id"])
 
 
+def test_writer_updates_publication_date_from_inspire_without_cds_doi(
+    running_app, location, transformed_record_1_file, scientific_community
+):
+    """Test INSPIRE publication-date mismatches update non-CDS DOI records."""
+    writer = InspireWriter()
+    transformed_record = deepcopy(transformed_record_1_file)
+
+    writer.write_many([StreamEntry(transformed_record)])
+    RDMRecord.index.refresh()
+    created = current_rdm_records_service.search(
+        system_identity,
+        params={"q": f"metadata.title:{transformed_record['metadata']['title']}"},
+    ).to_dict()["hits"]["hits"][0]
+
+    transformed_record["metadata"]["publication_date"] = "2014"
+    update_entry = StreamEntry(transformed_record)
+    writer.write_many([update_entry])
+    RDMRecord.index.refresh()
+
+    updated = current_rdm_records_service.read(system_identity, created["id"])
+    assert updated["metadata"]["publication_date"] == "2014"
+    assert not update_entry.errors
+
+    _cleanup_record(created["id"])
+
+
+def test_writer_reports_publication_date_conflict_for_cds_doi(
+    running_app,
+    location,
+    monkeypatch,
+    transformed_record_1_file,
+    scientific_community,
+):
+    """Test CDS DOI records keep publication-date mismatches for review."""
+    monkeypatch.setitem(
+        running_app.app.config["RDM_PERSISTENT_IDENTIFIERS"]["doi"],
+        "required",
+        True,
+    )
+    writer = InspireWriter()
+    transformed_record = deepcopy(transformed_record_1_file)
+    transformed_record["metadata"]["publisher"] = "CERN"
+
+    writer.write_many([StreamEntry(transformed_record)])
+    RDMRecord.index.refresh()
+    created = current_rdm_records_service.search(
+        system_identity,
+        params={"q": f"metadata.title:{transformed_record['metadata']['title']}"},
+    ).to_dict()["hits"]["hits"][0]
+    assert created["pids"]["doi"]["provider"] == "datacite"
+
+    transformed_record["metadata"]["publication_date"] = "2014"
+    update_entry = StreamEntry(transformed_record)
+    writer.write_many([update_entry])
+    RDMRecord.index.refresh()
+
+    unchanged = current_rdm_records_service.read(system_identity, created["id"])
+    assert unchanged["metadata"]["publication_date"] == "2020"
+    assert any("[year_mismatch]" in error for error in update_entry.errors)
+
+    _cleanup_record(created["id"])
+
+
 def test_writer_1_existing_found_file_changed_new_version_created(
     running_app, location, transformed_record_1_file, scientific_community
 ):


### PR DESCRIPTION
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/846
This change reduces false harvester conflicts by treating INSPIRE as the source of truth for valid publication date differences. For regular records, the incoming INSPIRE publication date is now applied automatically instead of requiring manual conflict resolution. Records with a CDS-managed DOI remain on the existing strict conflict path because CDS is authoritative for those records. Genuine transformation failures and other update conflicts continue to be reported as errors.
Tests cover both regular records and CDS-DOI records to verify the two policies behave as expected.