### PR TITLE
fix(harvester): address minor splitter feedback

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -123,9 +123,6 @@ TRUSTED_HOSTS = ['0.0.0.0', 'localhost', '127.0.0.1', 'localhost.cern.ch']
 
 # TODO: Set
 SQLALCHEMY_DATABASE_URI = "postgresql+psycopg2://cds-rdm:cds-rdm@localhost/cds-rdm"
-SQLALCHEMY_ENGINE_OPTIONS={
-  "connect_args": {"options": "-c timezone=UTC"}
-}
 
 # Invenio-App
 # ===========

--- a/site/cds_rdm/inspire_harvester/load/draft.py
+++ b/site/cds_rdm/inspire_harvester/load/draft.py
@@ -42,7 +42,7 @@ class DraftLifecycleManager:
         """Create a new-version draft from an existing published record."""
         return current_rdm_records_service.new_version(system_identity, record_pid)
 
-    def add_community(self, draft):
+    def add_cern_research_community(self, draft):
         """Add the CERN Scientific Community to the draft."""
         with db.session.begin_nested():
             community_id = current_app.config["CDS_CERN_SCIENTIFIC_COMMUNITY_ID"]

--- a/site/cds_rdm/inspire_harvester/load/files.py
+++ b/site/cds_rdm/inspire_harvester/load/files.py
@@ -28,7 +28,7 @@ class RetryConfig:
 
 
 @dataclass
-class FileDiff:
+class FileChecksumsDiff:
     """Diff between existing and new file sets, keyed by checksum."""
 
     to_add: List[str]  # checksums of new files to upload
@@ -43,12 +43,12 @@ class FileSynchronizer:
         """Constructor."""
         self.retry_config = retry_config or RetryConfig()
 
-    def compute_diff(self, existing_files, new_files) -> FileDiff:
+    def compute_diff(self, existing_files, new_files) -> FileChecksumsDiff:
         """Return the set difference between existing and new file checksums."""
         existing_checksums = [value["checksum"] for value in existing_files.values()]
         new_checksums = [value["checksum"] for value in new_files.values()]
 
-        return FileDiff(
+        return FileChecksumsDiff(
             to_add=list(set(new_checksums) - set(existing_checksums)),
             to_delete=list(set(existing_checksums) - set(new_checksums)),
             existing=list(set(existing_checksums)),
@@ -175,6 +175,7 @@ class FileSynchronizer:
             file_data_to_init = {
                 k: v for k, v in file_data.items() if k != "source_url"
             }
+            logger.debug(f"Filename: '{file_data['key']}' initializing.")
             service.draft_files.init_files(
                 system_identity, draft.id, [file_data_to_init]
             )

--- a/site/cds_rdm/inspire_harvester/transform/mappers/preprint.py
+++ b/site/cds_rdm/inspire_harvester/transform/mappers/preprint.py
@@ -28,7 +28,7 @@ class PreprintFilesMapper(FilesMapper):
             return False
         if (not material or material == "preprint") and source == "arxiv":
             return True
-        if source == "CDS":
+        if source and source.lower() == "cds":
             # include it to check the file
             return True
         return False

--- a/site/cds_rdm/inspire_harvester/writer.py
+++ b/site/cds_rdm/inspire_harvester/writer.py
@@ -270,7 +270,7 @@ class InspireWriter(BaseWriter):
                 self.file_sync.sync(draft, {}, entry, logger)
                 logger.info("All the files successfully created.")
 
-            self.drafts.add_community(draft)
+            self.drafts.add_cern_research_community(draft)
         except Exception:
             current_rdm_records_service.delete_draft(system_identity, draft.id)
             logger.error(f"Draft {draft.id} is deleted due to errors.")

--- a/site/tests/inspire_harvester/conftest.py
+++ b/site/tests/inspire_harvester/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2025 CERN.
+# Copyright (C) 2026 CERN.
 #
 # CDS RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/site/tests/inspire_harvester/test_harvester_job.py
+++ b/site/tests/inspire_harvester/test_harvester_job.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2025 CERN.
+# Copyright (C) 2026 CERN.
 #
 # CDS-RDM is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.

--- a/site/tests/inspire_harvester/test_metadata_only_new_version.py
+++ b/site/tests/inspire_harvester/test_metadata_only_new_version.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2025 CERN.
+# Copyright (C) 2026 CERN.
 #
 # CDS-RDM is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.

--- a/site/tests/inspire_harvester/test_multiple_document_types_external.py
+++ b/site/tests/inspire_harvester/test_multiple_document_types_external.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2025 CERN.
+# Copyright (C) 2026 CERN.
 #
 # CDS-RDM is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.

--- a/site/tests/inspire_harvester/test_transformer.py
+++ b/site/tests/inspire_harvester/test_transformer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2025 CERN.
+# Copyright (C) 2026 CERN.
 #
 # CDS-RDM is free software; you can redistribute it and/or modify it under
 # the terms of the GPL-2.0 License; see LICENSE file for more details.

--- a/site/tests/inspire_harvester/test_writer.py
+++ b/site/tests/inspire_harvester/test_writer.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2025 CERN.
+# Copyright (C) 2026 CERN.
 #
 # CDS-RDM is free software; you can redistribute it and/or modify it under
 # the terms of the GPL-2.0 License; see LICENSE file for more details.

--- a/site/tests/inspire_harvester/utils.py
+++ b/site/tests/inspire_harvester/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2025 CERN.
+# Copyright (C) 2026 CERN.
 #
 # CDS RDM is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/site/tests/utils.py
+++ b/site/tests/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2025 CERN.
+# Copyright (C) 2026 CERN.
 #
 # CDS-RDM is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.


### PR DESCRIPTION
Part of #849. This PR covers the minor fixes and naming feedback from the document type splitter review. It makes the CDS source check case-insensitive, updates the affected license headers, removes the unused local SQLAlchemy engine configuration, renames the community and file-diff helpers to make their purpose clearer, moves the repeated traceback import to the module level, and adds a debug log when file initialization starts.