### PR TITLE
fix harvester files and affiliations

### DIFF
--- a/site/cds_rdm/inspire_harvester/load/draft.py
+++ b/site/cds_rdm/inspire_harvester/load/draft.py
@@ -53,6 +53,14 @@ class DraftLifecycleManager:
             draft_obj.parent.communities.default = community_id
             draft_obj.parent.commit()
 
+    def delete_files(self, draft_id, filenames, logger):
+        """Delete files from a draft."""
+        for filename in filenames:
+            logger.debug(f"Delete file: {filename}")
+            current_rdm_records_service.draft_files.delete_file(
+                system_identity, draft_id, filename
+            )
+
     def publish(self, draft_id, logger):
         """Publish a draft. Deletes the draft on any failure, then raises WriterError."""
         try:

--- a/site/cds_rdm/inspire_harvester/load/files.py
+++ b/site/cds_rdm/inspire_harvester/load/files.py
@@ -7,6 +7,7 @@
 
 """File synchronization module."""
 
+import hashlib
 import time
 from dataclasses import dataclass
 from io import BytesIO
@@ -17,6 +18,8 @@ from invenio_access.permissions import system_identity
 from invenio_rdm_records.proxies import current_rdm_records_service
 from invenio_records_resources.services.errors import FileKeyNotFoundError
 from invenio_vocabularies.datastreams.errors import WriterError
+
+from cds_rdm.inspire_harvester.load.draft import DraftLifecycleManager
 
 
 @dataclass
@@ -39,9 +42,24 @@ class FileDiff:
 class FileSynchronizer:
     """Handles file I/O, diffing, uploading, and deletion for draft records."""
 
-    def __init__(self, retry_config: RetryConfig = None):
+    def __init__(
+        self,
+        retry_config: RetryConfig = None,
+        draft_lifecycle: DraftLifecycleManager = None,
+    ):
         """Constructor."""
         self.retry_config = retry_config or RetryConfig()
+        self.draft_lifecycle = draft_lifecycle or DraftLifecycleManager()
+
+    def _populate_missing_checksums(self, files, logger):
+        """Calculate checksums for incoming files that do not provide one."""
+        for file_data in files.values():
+            if file_data.get("checksum") is None:
+                file_content = self.fetch(file_data.get("source_url"), logger)
+                digest = hashlib.md5(
+                    file_content.getvalue(), usedforsecurity=False
+                ).hexdigest()
+                file_data["checksum"] = f"md5:{digest}"
 
     def compute_diff(self, existing_files, new_files) -> FileDiff:
         """Return the set difference between existing and new file checksums."""
@@ -112,6 +130,7 @@ class FileSynchronizer:
             f" New files count: {len(new_files)}"
         )
 
+        self._populate_missing_checksums(new_files, logger)
         diff = self.compute_diff(existing_files, new_files)
         logger.debug(f"Existing files' checksums: {diff.existing}.")
         logger.debug(f"New files' checksums: {diff.to_add}.")
@@ -142,12 +161,12 @@ class FileSynchronizer:
         diff = self.compute_diff(existing_files, new_files)
         should_update_files = bool(new_files) and bool(diff.to_add or diff.to_delete)
         if should_update_files:
-            for filename, file_data in existing_files.items():
-                if file_data["checksum"] in diff.to_delete:
-                    logger.debug(f"Delete file: {filename}")
-                    current_rdm_records_service.draft_files.delete_file(
-                        system_identity, draft.id, filename
-                    )
+            files_to_delete = [
+                filename
+                for filename, file_data in existing_files.items()
+                if file_data["checksum"] in diff.to_delete
+            ]
+            self.draft_lifecycle.delete_files(draft.id, files_to_delete, logger)
 
             logger.info(f"{len(diff.to_delete)} files successfully deleted.")
 

--- a/site/cds_rdm/inspire_harvester/transform/mappers/contributors.py
+++ b/site/cds_rdm/inspire_harvester/transform/mappers/contributors.py
@@ -42,25 +42,31 @@ class CreatibutorsMapper(MapperBase):
     def _transform_author_affiliations(self, author):
         """Transform affiliations.
 
-        If affiliations_identifiers is present, ROR values are matched by index
-        to the affiliations list and used as vocabulary IDs. Affiliations without
-        a matching ROR fall back to free-text name.
+        Complete ROR coverage is mapped in ROR order. Otherwise, identifiers
+        are matched by source position and non-ROR affiliations use free text.
         """
         affiliations = author.get("affiliations", [])
-        affiliations_identifiers = author.get("affiliations_identifiers")
+        affiliations_identifiers = author.get("affiliations_identifiers", [])
         mapped_affiliations = []
 
-        ror_ids = []
-        if affiliations_identifiers:
-            ror_ids = [
-                normalize_ror(ai["value"])
-                for ai in affiliations_identifiers
-                if ai.get("schema") == "ROR"
-            ]
+        ror_ids = [
+            normalize_ror(identifier["value"])
+            for identifier in affiliations_identifiers
+            if identifier.get("schema") == "ROR"
+        ]
+        if len(ror_ids) == len(affiliations):
+            return [{"id": ror_id} for ror_id in ror_ids]
 
         for i, affiliation in enumerate(affiliations):
-            if i < len(ror_ids):
-                mapped_affiliations.append({"id": ror_ids[i]})
+            affiliation_identifier = (
+                affiliations_identifiers[i]
+                if i < len(affiliations_identifiers)
+                else {}
+            )
+            if affiliation_identifier.get("schema") == "ROR":
+                mapped_affiliations.append(
+                    {"id": normalize_ror(affiliation_identifier["value"])}
+                )
             else:
                 value = affiliation.get("value")
                 if value:

--- a/site/cds_rdm/inspire_harvester/transform/mappers/files.py
+++ b/site/cds_rdm/inspire_harvester/transform/mappers/files.py
@@ -37,7 +37,7 @@ class FilesMapper(MapperBase):
                 filename = file["filename"]
                 source = file.get("source")
                 url = file["url"]
-                if "pdf" not in filename:
+                if not filename.lower().endswith(".pdf"):
                     # INSPIRE only exposes pdfs for us
                     filename = f"{filename}.pdf"
 

--- a/site/cds_rdm/inspire_harvester/writer.py
+++ b/site/cds_rdm/inspire_harvester/writer.py
@@ -43,8 +43,8 @@ class InspireWriter(BaseWriter):
     def __init__(self):
         """Constructor."""
         self.matcher = RecordMatcher()
-        self.file_sync = FileSynchronizer()
         self.drafts = DraftLifecycleManager()
+        self.file_sync = FileSynchronizer(draft_lifecycle=self.drafts)
 
     def write(self, stream_entry, *args, **kwargs):
         """Create or update the record in CDS."""

--- a/site/tests/inspire_harvester/test_transformer.py
+++ b/site/tests/inspire_harvester/test_transformer.py
@@ -496,6 +496,25 @@ def test_transform_author_affiliations_with_ror_partial(running_app):
     assert {"name": "Unknown Institute"} in result
 
 
+def test_transform_author_affiliations_with_mixed_identifiers(running_app):
+    """Test non-ROR identifiers do not shift ROR affiliation matching."""
+    author = {
+        "affiliations": [
+            {"value": "University of Paris"},
+            {"value": "CERN"},
+        ],
+        "affiliations_identifiers": [
+            {"value": "grid.example", "schema": "GRID"},
+            {"value": "https://ror.org/01ggx4157", "schema": "ROR"},
+        ],
+    }
+
+    mapper = CreatibutorsMapper()
+    result = mapper._transform_author_affiliations(author)
+
+    assert result == [{"name": "University of Paris"}, {"id": "01ggx4157"}]
+
+
 def test_transform_copyrights_complete(running_app):
     """Test CopyrightMapper with complete copyright info."""
     src_metadata = {
@@ -859,6 +878,31 @@ def test_transform_files_pdf_extension(running_app):
 
     # Should not add .pdf extension if already present
     assert "document.pdf" in result["entries"]
+
+
+def test_transform_files_pdf_substring_is_not_an_extension(running_app):
+    """Test filenames containing 'pdf' still receive a .pdf extension."""
+    src_metadata = {
+        "documents": [
+            {
+                "filename": "Fulltext_pdf_paper",
+                "key": "abc123",
+                "url": "https://example.com/file",
+            }
+        ]
+    }
+    ctx = MetadataSerializationContext(
+        resource_type=ResourceType.OTHER, inspire_id="12345"
+    )
+    mapper = FilesMapper()
+
+    result = mapper.map_value(
+        {"metadata": src_metadata, "created": "2023-01-01"},
+        ctx,
+        Logger(inspire_id="12345"),
+    )
+
+    assert "Fulltext_pdf_paper.pdf" in result["entries"]
 
 
 def test_transform_publisher(running_app):

--- a/site/tests/inspire_harvester/test_writer.py
+++ b/site/tests/inspire_harvester/test_writer.py
@@ -7,6 +7,8 @@
 
 """ISNPIRE harvester writer tests."""
 from copy import deepcopy
+from io import BytesIO
+from unittest.mock import Mock
 
 import pytest
 from invenio_access.permissions import system_identity
@@ -14,12 +16,42 @@ from invenio_rdm_records.proxies import current_rdm_records, current_rdm_records
 from invenio_rdm_records.records.api import RDMRecord
 from invenio_vocabularies.datastreams import StreamEntry
 
+from cds_rdm.inspire_harvester.load.files import FileSynchronizer
 from cds_rdm.inspire_harvester.writer import InspireWriter
 
 
 def _cleanup_record(recid):
     """Delete a record after each test."""
     current_rdm_records.records_service.delete(system_identity, recid)
+
+
+def test_checksumless_file_is_unchanged_when_content_matches():
+    """Test checksum-less arXiv files are compared using downloaded content."""
+    content = b"unchanged arxiv file"
+    checksum = "md5:6b0586ad35a9ae10c5fe14842ff2366a"
+    record = Mock()
+    record.to_dict.return_value = {
+        "files": {"entries": {"paper.pdf": {"checksum": checksum}}}
+    }
+    incoming_record = {
+        "files": {
+            "entries": {
+                "paper.pdf": {
+                    "checksum": None,
+                    "source_url": "https://arxiv.org/pdf/1234.5678",
+                }
+            }
+        }
+    }
+    synchronizer = FileSynchronizer()
+    synchronizer.fetch = Mock(return_value=BytesIO(content))
+
+    should_update = synchronizer.check_files_should_update(
+        record, incoming_record, Mock()
+    )
+
+    assert should_update is False
+    assert incoming_record["files"]["entries"]["paper.pdf"]["checksum"] == checksum
 
 
 @pytest.fixture()


### PR DESCRIPTION
Part of #849. This PR addresses the Files and Affiliations feedback by correctly comparing arXiv files that arrive without checksums, fixing PDF extension handling, moving file deletion into the draft lifecycle, and ensuring ROR identifiers are matched to the correct affiliations while falling back to the affiliation name when no ROR is available. It also adds focused regression tests for the checksum, PDF filename, and mixed affiliation identifier cases.