### PR TITLE
fix(harvester): show loader while opening report

### DIFF
--- a/site/cds_rdm/assets/semantic-ui/js/cds_rdm/administration/harvesterReports/DownloadButton.js
+++ b/site/cds_rdm/assets/semantic-ui/js/cds_rdm/administration/harvesterReports/DownloadButton.js
@@ -4,44 +4,62 @@
 // CDS-RDM is free software; you can redistribute it and/or modify it
 // under the terms of the GPL-2.0 License; see LICENSE file for more details.
 
-import React from "react";
+import React, { useState } from "react";
+import PropTypes from "prop-types";
 import { Button, Icon } from "semantic-ui-react";
 import { i18next } from "@translations/invenio_administration/i18next";
 
-export const DownloadButton = ({ runId }) => (
-  <div className="ui horizontal list">
-    <div className="item">
-      <Button
-        icon
-        labelPosition="left"
-        onClick={() => {
-          if (!runId) return;
-          const q = new URLSearchParams({ run_id: runId });
-          window.location.href = `/harvester-reports/download?${q}`;
-        }}
-        disabled={!runId}
-        className="harvester-download-log-button"
-        size="small"
-      >
-        <Icon name="download" />
-        {i18next.t("Download error logs")}
-      </Button>
+export const DownloadButton = ({ runId }) => {
+  const [isLoadingReport, setIsLoadingReport] = useState(false);
+
+  const handleViewReport = () => {
+    if (!runId || isLoadingReport) return;
+
+    setIsLoadingReport(true);
+    window.location.assign(`/administration/harvester-reports/${runId}/report`);
+  };
+
+  return (
+    <div className="ui horizontal list">
+      <div className="item">
+        <Button
+          icon
+          labelPosition="left"
+          onClick={() => {
+            if (!runId) return;
+            const q = new URLSearchParams({ run_id: runId });
+            window.location.href = `/harvester-reports/download?${q}`;
+          }}
+          disabled={!runId}
+          className="harvester-download-log-button"
+          size="small"
+        >
+          <Icon name="download" />
+          {i18next.t("Download error logs")}
+        </Button>
+      </div>
+      <div className="item">
+        <Button
+          icon
+          labelPosition="left"
+          onClick={handleViewReport}
+          loading={isLoadingReport}
+          disabled={!runId || isLoadingReport}
+          className="harvester-view-logs-button"
+          size="small"
+        >
+          <Icon name="file alternate outline" />
+          {i18next.t("View error logs")}
+        </Button>
+      </div>
     </div>
-    <div className="item">
-      <Button
-        icon
-        labelPosition="left"
-        onClick={() => {
-          if (!runId) return;
-          window.location.assign(`/administration/harvester-reports/${runId}/report`);
-        }}
-        disabled={!runId}
-        className="harvester-view-logs-button"
-        size="small"
-      >
-        <Icon name="file alternate outline" />
-        {i18next.t("View error logs")}
-      </Button>
-    </div>
-  </div>
-);
+  );
+};
+
+DownloadButton.propTypes = {
+  runId: PropTypes.string,
+};
+
+DownloadButton.defaultProps = {
+  runId: null,
+};


### PR DESCRIPTION
Part of #849. 
The harvester error report can take some time to open, so users may think the button did not work and click it repeatedly. This adds a loading indicator to the “View error logs” button and disables it after the first click until the report page loads.