### PR TITLE
feat(ep): allow referees to view new record versions

### DIFF
--- a/assets/js/components/record_details/NewVersionButton.js
+++ b/assets/js/components/record_details/NewVersionButton.js
@@ -27,9 +27,8 @@ export const NewVersionButton = ({ onError, record, disabled, ...uiProps }) => {
     committeeApproval?.approval_label || i18next.t("Committee approval");
 
   const handleClick = useCallback(async () => {
-    if (["submitted", "accepted"].includes(committeeApprovalStatus) && !showModal) {
-      // If a request exists, we discourage creating a new version.
-      // This applies even if the request has been accepted.
+    if (committeeApprovalStatus === "submitted" && !showModal) {
+      // If a request is pending, we discourage creating a new version.
       setShowModal(true);
       return;
     } else if (showModal) {
@@ -78,41 +77,25 @@ export const NewVersionButton = ({ onError, record, disabled, ...uiProps }) => {
         <Modal.Header>
           <Icon name="warning sign" color="yellow" className="mr-10" />
 
-          {committeeApprovalStatus === "submitted" &&
-            i18next.t("{{approvalLabel}} request pending", {
-              approvalLabel,
-            })}
-          {committeeApprovalStatus === "accepted" &&
-            i18next.t("{{approvalLabel}} already complete", {
-              approvalLabel,
-            })}
+          {i18next.t("{{approvalLabel}} request pending", {
+            approvalLabel,
+          })}
         </Modal.Header>
         <Modal.Content>
-          {committeeApprovalStatus === "submitted" && (
-            <>
-              <p>
-                {i18next.t(
-                  "An {{approvalLabel}} request is already pending for an existing version of this record. " +
-                    "A new version will not be taken into account for the {{approvalLabel}} request.",
-                  {
-                    approvalLabel,
-                  }
-                )}
-              </p>
-              <p>
-                {i18next.t(
-                  "Creating a new version while the request is pending is not recommended."
-                )}
-              </p>
-            </>
-          )}
-          {committeeApprovalStatus === "accepted" && (
-            <p>
-              {i18next.t(
-                "A version of this record has already been approved. Creating a new version following an approved request is not recommended."
-              )}
-            </p>
-          )}
+          <p>
+            {i18next.t(
+              "An {{approvalLabel}} request is already pending for an existing version of this record. " +
+                "A new version will not be taken into account for the {{approvalLabel}} request.",
+              {
+                approvalLabel,
+              }
+            )}
+          </p>
+          <p>
+            {i18next.t(
+              "Creating a new version while the request is pending is not recommended."
+            )}
+          </p>
         </Modal.Content>
         <Modal.Actions>
           <Button onClick={() => setShowModal(false)} floated="left">

--- a/site/cds_rdm/generators.py
+++ b/site/cds_rdm/generators.py
@@ -12,6 +12,7 @@ from flask import current_app
 from flask_principal import RoleNeed, UserNeed
 from invenio_access import action_factory
 from invenio_access.permissions import Permission
+from invenio_rdm_records.services.generators import AccessGrant
 from invenio_records_permissions.generators import AuthenticatedUser, Generator
 from invenio_search.engine import dsl
 
@@ -180,20 +181,31 @@ class EPWorkflowCommunityManager(Generator):
 
 COMMITTEE_APPROVAL_GRANT_ORIGIN_PREFIX = "committee-approval:"
 COMMITTEE_APPROVAL_GRANT_PERMISSION = "committee-review"
+COMMITTEE_APPROVAL_ACCESS_GRANT = AccessGrant(COMMITTEE_APPROVAL_GRANT_PERMISSION)
 
 
-def committee_approval_grant_origin(version_uuid):
-    """Return the grant origin string for a specific record version UUID."""
-    return f"{COMMITTEE_APPROVAL_GRANT_ORIGIN_PREFIX}{version_uuid}"
+def committee_approval_grant_origin(record_pid: str, version_index: int):
+    """Return the grant origin string for a specific record version index."""
+    return f"{COMMITTEE_APPROVAL_GRANT_ORIGIN_PREFIX}{record_pid}_{version_index}"
+
+
+def get_version_index_from_origin(origin: str):
+    """Returns just the version index number from the grant origin."""
+    id_and_version_str = origin.removeprefix(COMMITTEE_APPROVAL_GRANT_ORIGIN_PREFIX)
+    components = id_and_version_str.split("_")
+    if len(components) != 2:
+        return None
+    _, version_str = components
+    if not version_str.isdigit():
+        return None
+    return int(version_str)
 
 
 class CommitteeRefereeVersionGrant(Generator):
-    """Read access for committee referees scoped to the exact version they reviewed.
+    """Read access for committee referees scoped to the exact version they reviewed, as well as newer versions created after the approval was granted.
 
-    Grants are stored on the parent with a custom permission level
-    ``"committee-review"`` and ``origin="committee-approval:<version-uuid>"``.
-    Only the version whose UUID matches the origin will satisfy this generator —
-    other versions in the same family are excluded.
+    Later versions than the one for which the review was requested are only be accessible
+    if they were created after the review was approved.
 
     On submit  → grant added (version UUID = topic.id at submit time).
     On accept  → grant kept; referees retain permanent access to that version.
@@ -204,16 +216,18 @@ class CommitteeRefereeVersionGrant(Generator):
         """Return the RoleNeed if this version has a matching committee review grant."""
         if record is None:
             return []
-        version_origin = committee_approval_grant_origin(record.id)
-        return {
-            grant.to_need()
-            for grant in record.parent.access.grants
-            if (
-                grant.permission == COMMITTEE_APPROVAL_GRANT_PERMISSION
-                and grant.origin == version_origin
-            )
-        }
 
-    def query_filter(self, **kwargs):
-        """Not used for search filters."""
-        return []
+        needs = []
+        for grant in record.parent.access.grants:
+            if grant.permission != COMMITTEE_APPROVAL_GRANT_PERMISSION:
+                continue
+
+            grant_version = get_version_index_from_origin(grant.origin)
+            if grant_version is not None and record.versions.index >= grant_version:
+                needs.append(grant.to_need())
+
+        return needs
+
+    def query_filter(self, identity=None, **kwargs):
+        """Filter for records with a committee review grant for one of the identity's roles."""
+        return COMMITTEE_APPROVAL_ACCESS_GRANT.query_filter(identity, kwargs=kwargs)

--- a/site/cds_rdm/requests/committee_approval.py
+++ b/site/cds_rdm/requests/committee_approval.py
@@ -67,7 +67,9 @@ def _resolve_community_config(request):
             "The record is not part of any community. "
             "It must belong to a committee-approval-enabled community before submitting."
         )
-    committee_communities = current_app.config.get("CDS_COMMITTEE_APPROVAL_COMMUNITIES", {})
+    committee_communities = current_app.config.get(
+        "CDS_COMMITTEE_APPROVAL_COMMUNITIES", {}
+    )
     if default_community_id in committee_communities:
         return committee_communities[default_community_id]
     raise ValidationError(
@@ -98,8 +100,10 @@ class CommitteeApprovalSubmitAction(actions.CreateAndSubmitAction):
         config = _resolve_community_config(self.request)
 
         # Reject if the parent already carries an approval report number.
-        if ((topic.parent.get("permission_flags") or {}).get("committee_approval") or {}).get(
-            "reportnumber"
+        if (
+            topic.parent.get("permission_flags", {})
+            .get("committee_approval", {})
+            .get("reportnumber")
         ):
             raise ValidationError(
                 "A version of this record already has an approval report number assigned. "
@@ -146,7 +150,8 @@ class CommitteeApprovalSubmitAction(actions.CreateAndSubmitAction):
             subject_type="role",
             subject_id=config["referee_group"],
             permission=COMMITTEE_APPROVAL_GRANT_PERMISSION,
-            origin=committee_approval_grant_origin(topic.id),
+            # `topic.id` = uuid and `topic["id"]` = the PID 🙃
+            origin=committee_approval_grant_origin(topic["id"], topic.versions.index),
         )
         uow.register(
             ParentRecordCommitOp(
@@ -272,7 +277,7 @@ class CommitteeApprovalAcceptAction(actions.AcceptAction):
 def _remove_committee_approval_grant(request, uow):
     """Remove the committee approval referee grant from the record's parent."""
     topic = request.topic.resolve()
-    origin = committee_approval_grant_origin(topic.id)
+    origin = committee_approval_grant_origin(topic["id"], topic.versions.index)
     topic.parent.access.grants[:] = [
         g for g in topic.parent.access.grants if g.origin != origin
     ]

--- a/site/tests/test_committee_approval.py
+++ b/site/tests/test_committee_approval.py
@@ -164,7 +164,9 @@ def test_approval_rn_invalid_formats():
 
 def test_committee_approval_request_type_is_registered(app):
     """CommitteeApprovalRequest must be discoverable via the request type registry."""
-    request_type = current_request_type_registry.lookup("committee-approval", quiet=True)
+    request_type = current_request_type_registry.lookup(
+        "committee-approval", quiet=True
+    )
     assert request_type is not None
     assert request_type.type_id == "committee-approval"
 
@@ -290,7 +292,10 @@ def test_committee_approval_second_request_increments_sequence(
 
     service = current_rdm_records.records_service
     record2 = _publish_record_in_community(
-        community_manager.identity, minimal_restricted_record, committee_enrolled_community, service
+        community_manager.identity,
+        minimal_restricted_record,
+        committee_enrolled_community,
+        service,
     )
 
     r2 = current_requests_service.create(
@@ -444,7 +449,8 @@ def test_apprn_identifier_derived_from_parent(
     record = service.publish(system_identity, id_=sys_draft.id)
 
     apprn_ids = [
-        i for i in record.data.get("metadata", {}).get("identifiers", [])
+        i
+        for i in record.data.get("metadata", {}).get("identifiers", [])
         if i.get("scheme") == "apprn"
     ]
     assert len(apprn_ids) == 0, "Internal draft must NOT carry the apprn identifier"
@@ -464,7 +470,8 @@ def test_apprn_identifier_derived_from_parent(
     record2 = service.publish(system_identity, id_=sys_draft2.id)
 
     apprn_ids = [
-        i for i in record2.data.get("metadata", {}).get("identifiers", [])
+        i
+        for i in record2.data.get("metadata", {}).get("identifiers", [])
         if i.get("scheme") == "apprn"
     ]
     assert len(apprn_ids) == 1 and apprn_ids[0]["identifier"] == report_number
@@ -540,11 +547,9 @@ def test_referee_grant_added_on_submit_removed_on_decline(
 
     request_type = current_request_type_registry.lookup("committee-approval")
 
-    pid_obj = PersistentIdentifier.get(
-        "recid", record_in_enrolled_community.id
+    expected_origin = (
+        f"{COMMITTEE_APPROVAL_GRANT_ORIGIN_PREFIX}{record_in_enrolled_community.id}_1"
     )
-    record_uuid = pid_obj.object_uuid
-    expected_origin = f"{COMMITTEE_APPROVAL_GRANT_ORIGIN_PREFIX}{record_uuid}"
 
     request = current_requests_service.create(
         identity=community_manager.identity,
@@ -555,9 +560,12 @@ def test_referee_grant_added_on_submit_removed_on_decline(
     )
 
     # Grant must be present after submit.
+    pid_obj = PersistentIdentifier.get("recid", record_in_enrolled_community.id)
+    record_uuid = pid_obj.object_uuid
     rec = RDMRecord.get_record(record_uuid)
     grants = [
-        g for g in rec.parent.access.grants
+        g
+        for g in rec.parent.access.grants
         if g.permission == COMMITTEE_APPROVAL_GRANT_PERMISSION
         and g.origin == expected_origin
     ]
@@ -574,7 +582,8 @@ def test_referee_grant_added_on_submit_removed_on_decline(
     # Grant must be removed after decline.
     rec = RDMRecord.get_record(record_uuid)
     remaining = [
-        g for g in rec.parent.access.grants
+        g
+        for g in rec.parent.access.grants
         if g.permission == COMMITTEE_APPROVAL_GRANT_PERMISSION
         and g.origin == expected_origin
     ]
@@ -600,11 +609,9 @@ def test_referee_grant_retained_after_accept(
 
     request_type = current_request_type_registry.lookup("committee-approval")
 
-    pid_obj = PersistentIdentifier.get(
-        "recid", record_in_enrolled_community.id
+    expected_origin = (
+        f"{COMMITTEE_APPROVAL_GRANT_ORIGIN_PREFIX}{record_in_enrolled_community.id}_1"
     )
-    record_uuid = pid_obj.object_uuid
-    expected_origin = f"{COMMITTEE_APPROVAL_GRANT_ORIGIN_PREFIX}{record_uuid}"
 
     request = current_requests_service.create(
         identity=community_manager.identity,
@@ -620,9 +627,12 @@ def test_referee_grant_retained_after_accept(
         data={"payload": {"content": "<p>.</p>", "format": "html"}},
     )
 
+    pid_obj = PersistentIdentifier.get("recid", record_in_enrolled_community.id)
+    record_uuid = pid_obj.object_uuid
     rec = RDMRecord.get_record(record_uuid)
     grants = [
-        g for g in rec.parent.access.grants
+        g
+        for g in rec.parent.access.grants
         if g.permission == COMMITTEE_APPROVAL_GRANT_PERMISSION
         and g.origin == expected_origin
     ]
@@ -637,19 +647,23 @@ def test_referee_grant_scoped_to_submitted_version(
     app,
     db,
 ):
-    """Referee can read the submitted version but not a new version created afterwards."""
+    """Referee can read the submitted version and new versions created afterwards, but not any versions created before submission."""
     from invenio_rdm_records.proxies import current_rdm_records
 
     request_type = current_request_type_registry.lookup("committee-approval")
     service = current_rdm_records.records_service
 
-    # Submit and accept the request for v1.
+    # Create v2.
+    v2_draft = service.new_version(system_identity, id_=record_in_enrolled_community.id)
+    v2 = service.publish(system_identity, id_=v2_draft.id)
+
+    # Submit and accept the request for v2.
     request = current_requests_service.create(
         identity=community_manager.identity,
         data=ep_request_payload,
         request_type=request_type,
         receiver={"group": EP_GROUP_NAME},
-        topic={"record": record_in_enrolled_community.id},
+        topic={"record": v2.id},
     )
     current_requests_service.execute_action(
         identity=ep_referee.identity,
@@ -658,16 +672,16 @@ def test_referee_grant_scoped_to_submitted_version(
         data={"payload": {"content": "<p>.</p>", "format": "html"}},
     )
 
-    # Referee can read v1.
-    v1 = service.read(
-        identity=ep_referee.identity, id_=record_in_enrolled_community.id
-    )
-    assert v1.id == record_in_enrolled_community.id
-
-    # Create v2.
-    v2_draft = service.new_version(system_identity, id_=record_in_enrolled_community.id)
-    v2 = service.publish(system_identity, id_=v2_draft.id)
-
-    # Referee must NOT be able to read v2 — grant is scoped to v1's UUID.
+    # Referee should not be able to read v1 (created before review submission).
     with pytest.raises(RecordPermissionDeniedError):
-        service.read(identity=ep_referee.identity, id_=v2.id)
+        service.read(identity=ep_referee.identity, id_=record_in_enrolled_community.id)
+
+    # Referee should be able to read v2 (the submitted version)
+    service.read(identity=ep_referee.identity, id_=v2.id)
+
+    # Create v3.
+    v3_draft = service.new_version(system_identity, id_=record_in_enrolled_community.id)
+    v3 = service.publish(system_identity, id_=v3_draft.id)
+
+    # Referee should be able to view v3 (created after request submitted)
+    service.read(identity=ep_referee.identity, id_=v3.id)


### PR DESCRIPTION
Closes #864 

---

* Changed the permissions so that EP referees are able to view versions of the restricted/internal record that were created after the approval was requested.

* Referees can now access:
  - The record submitted for review
  - All future versions of that record