### PR TITLE
fix(harvester): preserve contributor given names

### DIFF
--- a/site/cds_rdm/inspire_harvester/transform/mappers/contributors.py
+++ b/site/cds_rdm/inspire_harvester/transform/mappers/contributors.py
@@ -98,6 +98,7 @@ class CreatibutorsMapper(MapperBase):
                 else:
                     try:
                         last_name, first_name = full_name.split(", ")
+                        rdm_creatibutor["person_or_org"]["given_name"] = first_name
                         rdm_creatibutor["person_or_org"]["family_name"] = last_name
                     except ValueError:
                         rdm_creatibutor["person_or_org"]["family_name"] = full_name


### PR DESCRIPTION
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/861
The INSPIRE harvester was losing authors’ given names when INSPIRE provided only a combined `full_name`, such as `Gwenlan, Claire`, instead of separate `first_name` and `last_name` fields. The mapper already split the combined name but only stored the family name. This PR also stores the extracted given name, so both parts are preserved and authors are displayed correctly on the CDS record page after the record is harvested again.