### PR TITLE
fix(harvester): error on editions and map multi DOIs

### DIFF
--- a/site/cds_rdm/inspire_harvester/transform/context.py
+++ b/site/cds_rdm/inspire_harvester/transform/context.py
@@ -21,3 +21,5 @@ class MetadataSerializationContext:
     inspire_id: str
     cds_rdm_id: Optional[str] = None
     errors: List[str] = field(default_factory=list)
+    # Extra DOIs (non-main) to append as related identifiers.
+    extra_related_dois: List[str] = field(default_factory=list)

--- a/site/cds_rdm/inspire_harvester/transform/mappers/custom_fields.py
+++ b/site/cds_rdm/inspire_harvester/transform/mappers/custom_fields.py
@@ -48,6 +48,13 @@ class ImprintMapper(MapperBase):
 
         # TODO this is true only for thesis
         isbn = online_isbns[0] if online_isbns else None
+        editions = src_metadata.get("editions", [])
+        if editions:
+            ctx.errors.append(
+                "Editions are not mapped. "
+                f"| details: editions={editions}"
+            )
+
         out = {}
         if place:
             out["place"] = place

--- a/site/cds_rdm/inspire_harvester/transform/mappers/identifiers.py
+++ b/site/cds_rdm/inspire_harvester/transform/mappers/identifiers.py
@@ -28,7 +28,12 @@ class DOIMapper(MapperBase):
         return True
 
     def map_value(self, src_record, ctx, logger):
-        """Mapping of record dois."""
+        """Mapping of record dois.
+
+        Prefer a CDS/DataCite-prefix DOI as the main PID. Any other DOIs become
+        related identifiers (via ctx.extra_related_dois). Multiple non-CDS DOIs
+        with no CDS DOI remain an error.
+        """
         src_metadata = src_record.get("metadata", {})
         DATACITE_PREFIX = current_app.config["DATACITE_PREFIX"]
         dois = src_metadata.get("dois", [])
@@ -47,25 +52,55 @@ class DOIMapper(MapperBase):
             if not self.filter(doi):
                 unique_dois.remove(doi)
 
-        if len(unique_dois) > 1:
+        if not unique_dois:
+            return None
+
+        cds_dois = [
+            d for d in unique_dois if d.get("value", "").startswith(DATACITE_PREFIX)
+        ]
+        other_dois = [
+            d
+            for d in unique_dois
+            if not d.get("value", "").startswith(DATACITE_PREFIX)
+        ]
+
+        if len(cds_dois) > 1:
+            ctx.errors.append(
+                "More than 1 CDS DOI was found. "
+                f"| details: dois={[d.get('value') for d in cds_dois]}"
+            )
+            return None
+
+        if cds_dois:
+            main = cds_dois[0]
+            extras = other_dois
+        elif len(other_dois) > 1:
             ctx.errors.append("More than 1 DOI was found.")
             return None
-        elif len(unique_dois) == 0:
-            return None
+        elif len(other_dois) == 1:
+            main = other_dois[0]
+            extras = []
         else:
-            doi = unique_dois[0].get("value")
-            if is_doi(doi):
-                mapped_doi = {
-                    "identifier": doi,
-                }
-                if doi.startswith(DATACITE_PREFIX):
-                    mapped_doi["provider"] = "datacite"
-                else:
-                    mapped_doi["provider"] = "external"
-                return {"doi": mapped_doi}
+            return None
+
+        doi = main.get("value")
+        if not is_doi(doi):
+            ctx.errors.append(f"DOI validation failed. | details: doi={doi}")
+            return None
+
+        for extra in extras:
+            value = extra.get("value")
+            if is_doi(value):
+                ctx.extra_related_dois.append(value)
             else:
-                ctx.errors.append(f"DOI validation failed. | details: doi={doi}")
-                return None
+                ctx.errors.append(f"DOI validation failed. | details: doi={value}")
+
+        mapped_doi = {"identifier": doi}
+        if doi.startswith(DATACITE_PREFIX):
+            mapped_doi["provider"] = "datacite"
+        else:
+            mapped_doi["provider"] = "external"
+        return {"doi": mapped_doi}
 
 
 @dataclass(frozen=True)
@@ -217,6 +252,16 @@ class RelatedIdentifiersMapper(MapperBase):
                         "identifier": f"{rn['value']}",
                         "relation_type": {"id": "isvariantformof"},
                         "resource_type": {"id": ctx.resource_type.value},
+                    }
+                )
+
+            for doi in ctx.extra_related_dois:
+                identifiers.append(
+                    {
+                        "identifier": doi,
+                        "scheme": "doi",
+                        "relation_type": {"id": "isversionof"},
+                        "resource_type": {"id": "publication-other"},
                     }
                 )
 

--- a/site/cds_rdm/inspire_harvester/writer.py
+++ b/site/cds_rdm/inspire_harvester/writer.py
@@ -221,10 +221,13 @@ class InspireWriter(BaseWriter):
 
         new_version_entry = deepcopy(update_metadata)
 
-        if "pids" in new_version_entry:
-            del new_version_entry["pids"]["oai"]
-            if new_version_entry["pids"]["doi"]["provider"] != "external":
-                del new_version_entry["pids"]["doi"]
+        pids = new_version_entry.get("pids")
+        if pids:
+            # Transformed entries often only carry doi (no oai).
+            pids.pop("oai", None)
+            doi = pids.get("doi")
+            if doi and doi.get("provider") != "external":
+                pids.pop("doi", None)
 
         logger.debug(f"New version draft created: {draft.id}")
         draft = self.drafts.update(draft, new_version_entry)

--- a/site/tests/inspire_harvester/test_transformer.py
+++ b/site/tests/inspire_harvester/test_transformer.py
@@ -182,7 +182,7 @@ def test_transform_dois_invalid(mock_is_doi, running_app):
 
 
 def test_transform_dois_multiple(running_app):
-    """Test DOIMapper with multiple DOIs."""
+    """Test DOIMapper errors when multiple non-CDS DOIs and no CDS DOI."""
     src_metadata = {
         "dois": [
             {"value": "10.1000/test1"},
@@ -200,6 +200,96 @@ def test_transform_dois_multiple(running_app):
     result = mapper.map_value(src_record, ctx, logger)
     assert result is None
     assert len(ctx.errors) == 1
+    assert "More than 1 DOI was found." in ctx.errors[0]
+
+
+@patch("cds_rdm.inspire_harvester.transform.mappers.identifiers.is_doi")
+def test_transform_dois_cds_with_external(mock_is_doi, running_app):
+    """CDS DOI becomes main PID; other DOIs go to related identifiers."""
+    mock_is_doi.return_value = True
+    src_metadata = {
+        "dois": [
+            {"value": "10.1000/external"},
+            {"value": "10.17181/cds-doi"},
+        ]
+    }
+    ctx = MetadataSerializationContext(
+        resource_type=ResourceType.OTHER, inspire_id="12345"
+    )
+    logger = Logger(inspire_id="12345")
+    mapper = DOIMapper()
+    src_record = {"metadata": src_metadata, "created": "2023-01-01"}
+
+    result = mapper.map_value(src_record, ctx, logger)
+
+    assert result["doi"]["identifier"] == "10.17181/cds-doi"
+    assert result["doi"]["provider"] == "datacite"
+    assert ctx.extra_related_dois == ["10.1000/external"]
+    assert not ctx.errors
+
+
+@patch("cds_rdm.inspire_harvester.transform.mappers.identifiers.is_doi")
+def test_transform_related_identifiers_includes_extra_dois(mock_is_doi, running_app):
+    """RelatedIdentifiersMapper appends DOIs queued by DOIMapper."""
+    mock_is_doi.return_value = True
+    ctx = MetadataSerializationContext(
+        resource_type=ResourceType.OTHER, inspire_id="12345"
+    )
+    ctx.extra_related_dois.append("10.1000/external")
+    logger = Logger(inspire_id="12345")
+    mapper = RelatedIdentifiersMapper()
+    src_record = {"metadata": {}, "created": "2023-01-01"}
+
+    result = mapper.map_value(src_record, ctx, logger)
+
+    assert {
+        "identifier": "10.1000/external",
+        "scheme": "doi",
+        "relation_type": {"id": "isversionof"},
+        "resource_type": {"id": "publication-other"},
+    } in result
+
+
+def test_transform_imprint_editions_error(running_app):
+    """Test ImprintMapper raises when editions are present."""
+    src_metadata = {
+        "imprints": [{"place": "Geneva"}],
+        "editions": ["2nd ed."],
+        "control_number": 12345,
+    }
+    ctx = MetadataSerializationContext(
+        resource_type=ResourceType.OTHER, inspire_id="12345"
+    )
+    logger = Logger(inspire_id="12345")
+    mapper = ImprintMapper()
+    src_record = {"metadata": src_metadata, "created": "2023-01-01"}
+
+    result = mapper.map_value(src_record, ctx, logger)
+
+    assert result["place"] == "Geneva"
+    assert "edition" not in result
+    assert len(ctx.errors) == 1
+    assert "Editions are not mapped." in ctx.errors[0]
+
+
+def test_transform_imprint_multiple_editions_error(running_app):
+    """Test ImprintMapper raises when multiple editions are present."""
+    src_metadata = {
+        "editions": ["1st ed.", "2nd ed."],
+        "control_number": 12345,
+    }
+    ctx = MetadataSerializationContext(
+        resource_type=ResourceType.OTHER, inspire_id="12345"
+    )
+    logger = Logger(inspire_id="12345")
+    mapper = ImprintMapper()
+    src_record = {"metadata": src_metadata, "created": "2023-01-01"}
+
+    result = mapper.map_value(src_record, ctx, logger)
+
+    assert "edition" not in result
+    assert len(ctx.errors) == 1
+    assert "Editions are not mapped." in ctx.errors[0]
 
 
 def test_transform_document_type_single(running_app):


### PR DESCRIPTION
This PR does the editions and DOI parts of #501.  if INSPIRE sends `metadata.editions`, we raise a curator error and do not map it to `imprint:imprint.edition`. (ForCDS currently has 0 records with editions).
For DOIs, if there’s a CDS/DataCite-prefix DOI we use that as the main PID and put the others into related identifiers (isversionof). If there’s no CDS DOI and more than one other DOI, we still raise an error like before so curators can handle it. Also added tests.

in the writer: when publishing a new version we still clear pids.oai and non-external pids.doi so fresh ones can be minted, but we do it with safe pops instead of del. Same behaviour as before, it just doesn’t crash when those keys aren’t present (which happens more often now that transformed entries often only carry a DOI).