### PR TITLE
fix(harvester): map public_notes to technical-info descriptions

### DIFF
--- a/site/cds_rdm/inspire_harvester/transform/mappers/basic_metadata.py
+++ b/site/cds_rdm/inspire_harvester/transform/mappers/basic_metadata.py
@@ -279,6 +279,13 @@ class AdditionalDescriptionsMapper(MapperBase):
                     {"description": book_volume, "type": {"id": "series-information"}}
                 )
 
+        for note in src_metadata.get("public_notes", []):
+            value = note.get("value")
+            if value:
+                additional_descriptions.append(
+                    {"description": value, "type": {"id": "technical-info"}}
+                )
+
         return additional_descriptions
 
 

--- a/site/tests/inspire_harvester/test_transformer.py
+++ b/site/tests/inspire_harvester/test_transformer.py
@@ -730,6 +730,33 @@ def test_transform_additional_descriptions(running_app):
     assert {"description": "Vol. 1", "type": {"id": "series-information"}} in result
 
 
+def test_transform_additional_descriptions_public_notes(running_app):
+    """Test public_notes map to additional_descriptions as technical-info."""
+    src_metadata = {
+        "public_notes": [
+            {
+                "value": "7 pages, 2 figures, proceedings for ACAT24",
+                "source": "arXiv",
+            }
+        ]
+    }
+    ctx = MetadataSerializationContext(
+        resource_type=ResourceType.OTHER, inspire_id="12345"
+    )
+    logger = Logger(inspire_id="12345")
+    mapper = AdditionalDescriptionsMapper()
+    src_record = {"metadata": src_metadata, "created": "2023-01-01"}
+
+    result = mapper.map_value(src_record, ctx, logger)
+
+    assert result == [
+        {
+            "description": "7 pages, 2 figures, proceedings for ACAT24",
+            "type": {"id": "technical-info"},
+        }
+    ]
+
+
 def test_transform_files(running_app):
     """Test FilesMapper."""
     src_metadata = {


### PR DESCRIPTION
Part of https://github.com/CERNDocumentServer/cds-rdm/issues/497
Map INSPIRE public_notes into metadata.additional_descriptions with type technical-info.