### PR TITLE
feat(components): allow thesis in CERN-related research community

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -452,6 +452,9 @@ CDS_EOS_OFFLOAD_REDIRECT_BASE_PATH = ""
 CDS_CERN_SCIENTIFIC_COMMUNITY_ID = ""
 """The id of the CERN Scientific community."""
 
+CDS_CERN_RELATED_RESEARCH_COMMUNITY_ID = ""
+"""The id of the CERN-Related Research community."""
+
 # EP / Publication Approval Workflow
 # ==================================
 

--- a/site/cds_rdm/components.py
+++ b/site/cds_rdm/components.py
@@ -40,22 +40,29 @@ class CDSResourcePublication(ServiceComponent):
 
     def _validate_thesis_community(self, identity, record_or_draft, errors=None):
         """Validate that a thesis is associated with the CERN Scientific Community."""
-        csc_community = current_communities.service.read(
-            identity, current_app.config["CDS_CERN_SCIENTIFIC_COMMUNITY_ID"]
-        )
+        allowed_community_ids = [
+            current_app.config["CDS_CERN_SCIENTIFIC_COMMUNITY_ID"],
+            current_app.config["CDS_CERN_RELATED_RESEARCH_COMMUNITY_ID"],
+        ]
 
-        if csc_community.id in record_or_draft.parent["communities"].get("ids", []):
-            return
+        for community_id in record_or_draft.parent["communities"].get("ids", []):
+            if community_id in allowed_community_ids:
+                return
 
         request_receiver = (
             record_or_draft.parent.review is not None
             and record_or_draft.parent.review.receiver.reference_dict.get("community")
         )
 
-        if not request_receiver or request_receiver != csc_community.id:
+        if not request_receiver or request_receiver not in allowed_community_ids:
+            community_titles = []
+            for community_id in allowed_community_ids:
+                community = current_communities.service.read(identity, community_id)
+                community_titles.append(community.data["metadata"]["title"])
+
             error_message = _(
-                "Thesis must be published in the "
-                f"'{csc_community.data['metadata']['title']}' community. Please select the community from the top header and submit the thesis for review."
+                "Theses must be published in one of the following communities: "
+                f"{', '.join(community_titles)}. Please select the community from the top header and submit the thesis for review."
             )
 
             if errors is not None:


### PR DESCRIPTION
Related to RQF3857136

Allows thesis records to be submitted not only to the `CDS_CERN_SCIENTIFIC_COMMUNITY_ID` but also a new config value `CDS_CERN_RELATED_RESEARCH_COMMUNITY_ID` and adjusts the error message as needed.