### PR TITLE
fix(harvester): keep volatile error details out of report groups

### DIFF
--- a/site/cds_rdm/inspire_harvester/load/files.py
+++ b/site/cds_rdm/inspire_harvester/load/files.py
@@ -111,11 +111,12 @@ class FileSynchronizer:
                 time.sleep(retry_delay)
 
         logger.error(
-            f"Retrieving file request failed. Max retries {max_retries} reached."
-            f" URL: {url}."
+            "Retrieving file request failed after max retries. "
+            f"| details: max_retries={max_retries}, url={url}"
         )
         raise WriterError(
-            "Could not fetch the INSPIRE file after repeated download failures."
+            "Could not fetch the INSPIRE file after repeated download failures. "
+            f"| details: url={url}"
         )
 
     def check_files_should_update(self, record, incoming_record, logger):

--- a/site/cds_rdm/inspire_harvester/logger.py
+++ b/site/cds_rdm/inspire_harvester/logger.py
@@ -28,6 +28,13 @@ def _validation_errors_to_text(error_dicts):
         message = ", ".join(compact_text(m) for m in messages if compact_text(m))
         if not message:
             continue
+        # Stable title for grouping; keep values after "| details:" for drill-down.
+        if message.lower().startswith("duplicated affiliations:"):
+            _, _, values = message.partition(":")
+            values = compact_text(values)
+            message = "Duplicated affiliations."
+            if values:
+                message = f"{message} | details: {values}"
         parts.append(f"{field}: {message}" if field else message)
     return parts
 
@@ -106,7 +113,8 @@ def raise_unexpected_operation_error(
     active_logger.exception(log_message)
 
     raise WriterError(
-        f"The {subject} could not be {action} because {describe_exception(error)}"
+        f"The {subject} could not be {action}. "
+        f"| details: {describe_exception(error)}"
     ) from error
 
 

--- a/site/cds_rdm/inspire_harvester/update/engine.py
+++ b/site/cds_rdm/inspire_harvester/update/engine.py
@@ -76,10 +76,12 @@ class UpdateEngine:
     def log_conflicts(self, conflicts, logger):
         """Log conflicts in given logger."""
         for conflict in conflicts:
+            # Stable group title; path/values stay after "| details:".
+            message = f"Update conflict. | details: {conflict}"
             if conflict.level == "warning":
-                logger.warning(str(conflict))
+                logger.warning(message)
             else:
-                logger.error(str(conflict))
+                logger.error(message)
             logger.debug(str(conflict.details))
 
     def update(self, current, incoming, ctx, logger):

--- a/site/cds_rdm/inspire_harvester/utils.py
+++ b/site/cds_rdm/inspire_harvester/utils.py
@@ -112,11 +112,13 @@ def search_vocabulary(term, vocab_type, ctx, logger):
         return vocabulary_result
     except RequestError as e:
         logger.error(
-            f"Failed vocabulary search ['{term}'] in '{vocab_type}'. INSPIRE#: {ctx.inspire_id}. Error: {e}."
+            f"Failed vocabulary search in '{vocab_type}'. "
+            f"| details: term={term}, error={e}"
         )
     except NoResultFound as e:
         logger.error(
-            f"Vocabulary term ['{term}'] not found in '{vocab_type}'. INSPIRE#: {ctx.inspire_id}"
+            f"Vocabulary term not found in '{vocab_type}'. "
+            f"| details: term={term}"
         )
         raise e
 

--- a/site/cds_rdm/inspire_harvester/writer.py
+++ b/site/cds_rdm/inspire_harvester/writer.py
@@ -69,7 +69,7 @@ class InspireWriter(BaseWriter):
         try:
             op_type = self._route(stream_entry)
         except UpdateEngineConflict as e:
-            error_message = "Update conflict: {}".format(
+            error_message = "Update conflict. | details: {}".format(
                 "; ".join(str(conflict) for conflict in e.conflicts)
             )
         except WriterError as e:


### PR DESCRIPTION
Closes #901

When many records fail for the same reason, the report was splitting them into separate groups because each message included different details (for example different university names).

This updates those error messages so the shared reason comes first and the variable details come after `| details:`. The report can then group by the reason, while the details are still visible when someone opens the group.