### PR TITLE
fix(harvester): error on withdrawn inspire records

### DIFF
--- a/site/cds_rdm/inspire_harvester/transform/config.py
+++ b/site/cds_rdm/inspire_harvester/transform/config.py
@@ -24,6 +24,7 @@ from cds_rdm.inspire_harvester.transform.mappers.basic_metadata import (
     ResourceTypeMapper,
     SubjectsMapper,
     TitleMapper,
+    WithdrawnMapper,
 )
 from cds_rdm.inspire_harvester.transform.mappers.contributors import (
     AuthorsMapper,
@@ -78,6 +79,7 @@ BASE_MAPPERS = (
     CERNFieldsMapper(),
     IdentifiersMapper(),
     RelatedIdentifiersMapper(),
+    WithdrawnMapper(),
 )
 
 THESIS_MAPPERS = (

--- a/site/cds_rdm/inspire_harvester/transform/mappers/basic_metadata.py
+++ b/site/cds_rdm/inspire_harvester/transform/mappers/basic_metadata.py
@@ -338,3 +338,20 @@ class LanguagesMapper(MapperBase):
                     f"Failed mapping language. | details: lang={lang}, error={e}"
                 )
         return mapped_langs
+
+
+@dataclass(frozen=True)
+class WithdrawnMapper(MapperBase):
+    """Reject withdrawn INSPIRE records."""
+
+    id = "withdrawn"
+
+    def map_value(self, src_record, ctx, logger):
+        """Error if the INSPIRE withdrawn field is set."""
+        if not (src_record.get("metadata") or {}).get("withdrawn"):
+            return None
+        ctx.errors.append(
+            "Record is withdrawn on INSPIRE. "
+            f"| details: cds_id={ctx.cds_rdm_id}"
+        )
+        return None


### PR DESCRIPTION
Part of https://github.com/CERNDocumentServer/cds-rdm/issues/906
if inspire marks a record as withdrawn we error and dont create/update it. if its already in cds we also put the cds id in the error so curators can open that record. if its not harvested yet we just say its withdrawn.