### PR TITLE
Pin invenio-assets to v4.2.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+Version 2.1.1 (released 2026-08-13)
+
+- setup: pin invenio-assets to 4.2.4
+
 Version 2.1.0 (released 2026-08-13)
 
 - setup: upgrade Python and JS dependencies
@@ -112,7 +116,7 @@ Version 1.29.0 (release 2026-04-01)
 - feat: add notifications for groups
 - feat: provide clc sync and harvester window access for curators
 - feat: harvester diff view
-- change: add reverse lookup in search for related identifiers 
+- change: add reverse lookup in search for related identifiers
 
 Version 1.28.1 (release 2026-03-13)
 
@@ -195,13 +199,13 @@ Version 1.24.1 (release 2026-01-16)
 
 Version 1.24.0 (release 2026-01-16)
 
-- refactor(templates): apply changes to customize file display name 
-- fix(templates): Add id to files list div 
-- refactor(redirector): Redirect /files to record with ?preview_file 
-- assets: overrides: Update lock/unlock helptext 
-- uv: upgrade version of app-rdm and react-invenio-forms 
-- feat(reply-comments): allow request users to reply when conversation is locked 
-- config: request locking enabled 
+- refactor(templates): apply changes to customize file display name
+- fix(templates): Add id to files list div
+- refactor(redirector): Redirect /files to record with ?preview_file
+- assets: overrides: Update lock/unlock helptext
+- uv: upgrade version of app-rdm and react-invenio-forms
+- feat(reply-comments): allow request users to reply when conversation is locked
+- config: request locking enabled
 - feat(previewer): add gltf previewer
 
 Version 1.23.0 (release 2026-01-08)
@@ -263,7 +267,7 @@ Version 1.19.0 (released 2025-11-06)
 Version 1.18.0 (released 2025-10-30)
 
 - installation: upgrade major dependencies
-- config:  Rename lcds -> cds
+- config: Rename lcds -> cds
 - config: Disable minting cdsrn identifier
 - feat(components): mint cdsrn to ensure uniqueness
 - config: rename cds_ref to cdsrn
@@ -480,7 +484,6 @@ Version 1.0.19 (released 2024-11-15)
 - gobal: integrates invenio-cern-sync and jobs
 - names: sync CERN authors into names
 
-
 Version 1.0.18 (released 2024-10-10)
 
 - package-lock: bump RSK version
@@ -536,44 +539,44 @@ Version 1.0.9 (released 2024-04-02)
 
 Version 1.0.8 (released 2024-02-09)
 
-* add support for file offloading
+- add support for file offloading
 
 Version 1.0.7 (released 2023-09-14)
 
-* make person_id optional arg on login for external accounts
+- make person_id optional arg on login for external accounts
 
 Version 1.0.6 (released 2023-09-12)
 
-* temporary fix in the record details template
+- temporary fix in the record details template
 
 Version 1.0.5 (released 2023-08-28)
 
-* bump invenio-oauthclient to integrate the changes in group fetching
+- bump invenio-oauthclient to integrate the changes in group fetching
 
 Version 1.0.4 (released 2023-08-25)
 
-* fix new version drafts pointing to edit drafts when cleanup_drafts script was
+- fix new version drafts pointing to edit drafts when cleanup_drafts script was
   running to purge all soft-deleted drafts (invenio-app-rdm/issues/2197)
-* update `read_latest` to be able to fetch record by passign the parent id (zenodo/rdm-project#174)
-* fetch groups async to improve login performance
+- update `read_latest` to be able to fetch record by passign the parent id (zenodo/rdm-project#174)
+- fetch groups async to improve login performance
 
 Version 1.0.3 (released 2023-08-17)
 
-* Fix temporarily permissions on who can add a record to a community so that
+- Fix temporarily permissions on who can add a record to a community so that
   community curators can submit a record to other communities
 
 Version 1.0.2 (released 2023-07-31)
 
-* Decrease user sync task logging level
+- Decrease user sync task logging level
 
 Version 1.0.1 (released 2023-07-28)
 
-* Improve e-mail templates
-* Add missing username field when syncing users from LDAP
+- Improve e-mail templates
+- Add missing username field when syncing users from LDAP
 
 Version 1.0.0 (released 2023-07-25)
 
-* Restrict who can create communities via role/user needs
-* Fix display banner
-* Make sync users/groups tasks running only on deployed envs
-* Add funders/awards
+- Restrict who can create communities via role/user needs
+- Fix display banner
+- Make sync users/groups tasks running only on deployed envs
+- Add funders/awards

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  "@fortawesome/fontawesome-free": true
+  "@parcel/watcher": true
+  "@swc/core": true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cds-rdm-app"
-version = "2.1.0"
+version = "2.1.1"
 authors = [
     { name = "CERN" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ override-dependencies = [
     # fastjsonschema>=2.22 starts to use type hints without this manual import and is
     # therefore incompatible with Python <=3.9. See https://github.com/horejsek/python-fastjsonschema/issues/211
     # Their minimum Python version has now been set to 3.10 for >=2.22
-    "fastjsonschema<2.22"
+    "fastjsonschema<2.22",
+    "invenio-assets<4.2.5"
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -874,7 +874,7 @@ source = { editable = "site" }
 
 [[package]]
 name = "cds-rdm-app"
-version = "2.1.0"
+version = "2.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "cds-rdm" },
@@ -3886,7 +3886,7 @@ wheels = [
 
 [[package]]
 name = "invenio-rdm-records"
-version = "34.0.1"
+version = "34.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arrow" },
@@ -3922,9 +3922,9 @@ dependencies = [
     { name = "pytz" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/5a/93d914f94ea39146d1a43c38d2862bfa5ed50a45413d6e751226ea501737/invenio_rdm_records-34.0.1.tar.gz", hash = "sha256:403521f2ece00af2b501eb2333f914c580855d337fee7f7674d15d0fad43940d", size = 1206318, upload-time = "2026-08-04T14:01:58.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/72/f26c143e78b68c629c5b554e5164e36b68d13aabd2e3c0ef48f783bcc55f/invenio_rdm_records-34.1.0.tar.gz", hash = "sha256:1627049958b9e82c9f28ac99d1c16587148b07dff677698ad8516bfa0ad42909", size = 1206447, upload-time = "2026-08-13T09:42:57.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/76/667299edb56e03a0645cb7ee22858c8096097b046f89bd6c7a8803a8473b/invenio_rdm_records-34.0.1-py3-none-any.whl", hash = "sha256:74574ab6f1c558b8cbdbc973953789775c709484e9983fe5ffe1ffe3500eb42b", size = 1802906, upload-time = "2026-08-04T14:01:55.882Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/fd/24504f0b611840705bc27a4bb2463eaf2e5f8d767225c8faa8780b7f1c82/invenio_rdm_records-34.1.0-py3-none-any.whl", hash = "sha256:6220d0391f38743dfd0c43815a6cd05d31e36987311631f978174e5dec6cebc9", size = 1803059, upload-time = "2026-08-13T09:42:54.975Z" },
 ]
 
 [[package]]
@@ -3975,7 +3975,7 @@ wheels = [
 
 [[package]]
 name = "invenio-records-resources"
-version = "11.0.2"
+version = "11.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel-edtf" },
@@ -3998,9 +3998,9 @@ dependencies = [
     { name = "xmltodict" },
     { name = "zipstream-ng" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/1e/7bf86f8497dbc726a720f6212ebb6f78add1491621c8c5bdf0b10327186d/invenio_records_resources-11.0.2.tar.gz", hash = "sha256:7b8021f28fec21a3fb4d57fcc048c3d69cd79c9a34938e1fe6da3522f510516d", size = 122006, upload-time = "2026-08-04T13:40:45.111Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/b0/8f9668a9462158b682cb7f51a6e5655f38b69093092d54d04c40c9bae03b/invenio_records_resources-11.0.3.tar.gz", hash = "sha256:1d3c62aac71719dfb50344233021444f93c7e697ca6e47be27f46778a6a89826", size = 122328, upload-time = "2026-08-13T09:40:36.051Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/ed/c1470e53c13f28ea02fbd6f513cd793c4269c464091ff6685e3eb5172cac/invenio_records_resources-11.0.2-py3-none-any.whl", hash = "sha256:9a7840be24bf4d3af23f2fc98f3db00b8755b368b919b165bfb5399826ffc3b3", size = 260694, upload-time = "2026-08-04T13:40:43.847Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ef/e8c71af6f6e803aebd19e549d70e7bfc3f6857576016a13791d57c220927/invenio_records_resources-11.0.3-py3-none-any.whl", hash = "sha256:a933356c4046a85003dc473a410b19761e59883f6e11820a2740e37f9b804421", size = 261082, upload-time = "2026-08-13T09:40:34.277Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,10 @@ members = [
     "cds-rdm",
     "cds-rdm-app",
 ]
-overrides = [{ name = "fastjsonschema", specifier = "<2.22" }]
+overrides = [
+    { name = "fastjsonschema", specifier = "<2.22" },
+    { name = "invenio-assets", specifier = "<4.2.5" },
+]
 
 [[package]]
 name = "aiobotocore"
@@ -3375,16 +3378,16 @@ opensearch2 = [
 
 [[package]]
 name = "invenio-assets"
-version = "4.2.6"
+version = "4.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask-collect-invenio" },
     { name = "flask-webpackext" },
     { name = "invenio-base" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/48/fd4ef5be71d4d3dadabd809c067db03d78c6a9111f901325285e3fbfbde3/invenio_assets-4.2.6.tar.gz", hash = "sha256:9f5e9e8136b51abe92caaaab451ea2bb0f5020fb90515005fd7ad7e4ddb7c696", size = 11860, upload-time = "2026-08-04T11:53:51.131Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/28/c06078979b18af770237f2699f086bbf8bfc143336783bcb22a361dd36db/invenio_assets-4.2.4.tar.gz", hash = "sha256:c55ecf5f2e1d22fbbe49f8575fb7a3a911f892b5994afc85649caa20ebd92bf8", size = 11861, upload-time = "2026-07-24T17:37:07.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/de/5d7869eb0b56848fb99ae915ca7c2a4e73a96fa380be160808d1d4af783d/invenio_assets-4.2.6-py3-none-any.whl", hash = "sha256:3dd3a3459ceb4acef62fbbd2c064041e0ed7b7d77717f03423876eec4d2ec3f7", size = 18492, upload-time = "2026-08-04T11:53:50.324Z" },
+    { url = "https://files.pythonhosted.org/packages/16/46/f1ef4713acccdc589689b08334139c8e87885f89ae7f3853ad2150b49d87/invenio_assets-4.2.4-py3-none-any.whl", hash = "sha256:1e71d66571312613f652b6c24375ab3e982fd1ea0b3485ed68cc8e83b1a9f41c", size = 18487, upload-time = "2026-07-24T17:37:06.578Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
v2.4.5 upgrades rspack to v2, which for now breaks our installation. So we are temporarily pinning it to v4.2.4