### PR TITLE
fix(committee-approval): remove leftover errors log for community submission

### DIFF
--- a/site/cds_rdm/requests/views.py
+++ b/site/cds_rdm/requests/views.py
@@ -267,12 +267,6 @@ def create_committee_approval_bp(app):
                         ]
                     },
                 )
-
-                if len(errors) != 0:
-                    current_app.logger.warning(
-                        f"Could not submit CREN Research inclusion request for "
-                        f"{new_record.data['id']}: {', '.join(errors)}"
-                    )
             except Exception as e:
                 current_app.logger.warning(
                     f"Could not submit CERN Research inclusion request for "


### PR DESCRIPTION
The `errors` variable is not defined anywhere in the context so I think this is leftover. We already have an error catcher here, so this is not needed.