### PR TITLE
fix(harvester): do not create records for unmatched EP approvals

### DIFF
--- a/site/cds_rdm/inspire_harvester/load/validator.py
+++ b/site/cds_rdm/inspire_harvester/load/validator.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 CERN.
+#
+# CDS-RDM is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+"""Record validation module."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from flask import current_app
+
+
+@dataclass(frozen=True)
+class ValidationRule(ABC):
+    """Base class for write-time validation rules."""
+
+    @abstractmethod
+    def check(self, stream_entry, *, record=None, record_pid=None, matcher=None):
+        """Return an error message when the write must not proceed, else ``None``."""
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class EpApprovalCreateRule(ValidationRule):
+    """Block create when the entry carries an EP approval number."""
+
+    def check(self, stream_entry, *, record=None, record_pid=None, matcher=None):
+        """Return an error if ``apprn`` is present on create."""
+        apprn = matcher._retrieve_identifier(
+            stream_entry.entry.get("metadata", {}).get("identifiers", []),
+            "apprn",
+        )
+        if not apprn:
+            return None
+        return (
+            "EP approval number did not match an existing record - EP approval "
+            "numbers can't be assigned outside CDS publishing workflow. "
+            f"| details: apprn={apprn}"
+        )
+
+
+@dataclass(frozen=True)
+class CdsDoiCreateRule(ValidationRule):
+    """Block create when the entry carries a CDS-minted DOI."""
+
+    def check(self, stream_entry, *, record=None, record_pid=None, matcher=None):
+        """Return an error if the entry DOI uses the CDS DataCite prefix."""
+        doi = stream_entry.entry.get("pids", {}).get("doi", {})
+        prefix = current_app.config["DATACITE_PREFIX"]
+        if prefix not in doi.get("identifier", ""):
+            return None
+        return (
+            "Trying to create record with CDS DOI "
+            "- record should be updated instead."
+        )
+
+
+@dataclass(frozen=True)
+class EpApprovalUpdateRule(ValidationRule):
+    """Block update when EP approval matches a restricted record."""
+
+    def check(self, stream_entry, *, record=None, record_pid=None, matcher=None):
+        """Return an error if ``apprn`` matches a restricted CDS record."""
+        apprn = matcher._retrieve_identifier(
+            stream_entry.entry.get("metadata", {}).get("identifiers", []),
+            "apprn",
+        )
+        if not apprn:
+            return None
+        if record.get("access", {}).get("record") != "restricted":
+            return None
+        return (
+            "EP approval number matched a restricted record - record must be "
+            "public to be updated by the harvester "
+            f"| details: apprn={apprn}, cds_id={record_pid}"
+        )
+
+
+CREATE_RULES = (EpApprovalCreateRule(), CdsDoiCreateRule())
+UPDATE_RULES = (EpApprovalUpdateRule(),)
+
+
+class RecordValidator:
+    """Runs mode-specific validation rules before create/update."""
+
+    def __init__(self, matcher):
+        """Constructor."""
+        self.matcher = matcher
+        self.create_rules = CREATE_RULES
+        self.update_rules = UPDATE_RULES
+
+    def validate(self, mode, stream_entry, record=None, record_pid=None):
+        """Return every failing rule message for the given write mode."""
+        rules = {
+            "create": self.create_rules,
+            "update": self.update_rules,
+        }[mode]
+        return [
+            msg
+            for rule in rules
+            if (
+                msg := rule.check(
+                    stream_entry,
+                    record=record,
+                    record_pid=record_pid,
+                    matcher=self.matcher,
+                )
+            )
+        ]

--- a/site/cds_rdm/inspire_harvester/writer.py
+++ b/site/cds_rdm/inspire_harvester/writer.py
@@ -19,6 +19,7 @@ from marshmallow import ValidationError
 from cds_rdm.inspire_harvester.load.draft import DraftLifecycleManager
 from cds_rdm.inspire_harvester.load.files import FileSynchronizer
 from cds_rdm.inspire_harvester.load.matcher import RecordMatcher
+from cds_rdm.inspire_harvester.load.validator import RecordValidator
 from cds_rdm.inspire_harvester.logger import (
     Logger,
     format_validation_error,
@@ -45,6 +46,7 @@ class InspireWriter(BaseWriter):
         self.matcher = RecordMatcher()
         self.drafts = DraftLifecycleManager()
         self.file_sync = FileSynchronizer(draft_lifecycle=self.drafts)
+        self.record_validator = RecordValidator(self.matcher)
 
     def write(self, stream_entry, *args, **kwargs):
         """Create or update the record in CDS."""
@@ -100,11 +102,15 @@ class InspireWriter(BaseWriter):
 
         elif match_result.found:
             logger.info(f"Matching record found: CDS#{match_result.record_pid}")
-            self._update_record(stream_entry, record_pid=match_result.record_pid)
+            if not self._update_record(
+                stream_entry, record_pid=match_result.record_pid
+            ):
+                return None
             return "update"
 
         else:
-            self._create_record(stream_entry)
+            if not self._create_record(stream_entry):
+                return None
             return "create"
 
     @hlog
@@ -116,6 +122,17 @@ class InspireWriter(BaseWriter):
         ctx = stream_entry.entry["_inspire_ctx"]
         record = current_rdm_records_service.read(system_identity, record_pid)
         record_dict = record.to_dict()
+        errors = self.record_validator.validate(
+            mode="update",
+            stream_entry=stream_entry,
+            record=record_dict,
+            record_pid=record_pid,
+        )
+        if errors:
+            for msg in errors:
+                logger.error(f"Error while processing entry: {msg}")
+                stream_entry.errors.append(f"[inspire_id={inspire_id}] {msg}")
+            return False
 
         should_update_files = self.file_sync.check_files_should_update(
             record, entry, logger
@@ -168,6 +185,7 @@ class InspireWriter(BaseWriter):
                     update_metadata,
                     logger,
                 )
+        return True
 
     def _resource_type_versioning(self, record, update_metadata, ctx, logger):
 
@@ -255,15 +273,13 @@ class InspireWriter(BaseWriter):
         self, stream_entry, inspire_id=None, record_pid=None, logger=None
     ):
         """Create and publish a new record draft for an incoming INSPIRE entry."""
+        errors = self.record_validator.validate(mode="create", stream_entry=stream_entry)
+        if errors:
+            for msg in errors:
+                logger.error(f"Error while processing entry: {msg}")
+                stream_entry.errors.append(f"[inspire_id={inspire_id}] {msg}")
+            return False
         entry = {k: v for k, v in stream_entry.entry.items() if k != "_inspire_ctx"}
-        ctx = stream_entry.entry["_inspire_ctx"]
-        doi = entry.get("pids", {}).get("doi", {})
-        DATACITE_PREFIX = current_app.config["DATACITE_PREFIX"]
-        if DATACITE_PREFIX in doi.get("identifier", ""):
-            raise WriterError(
-                "Trying to create record with CDS DOI "
-                "- record should be updated instead."
-            )
 
         file_entries = entry["files"].get("entries") or {}
         logger.debug(f"Files to create: {len(file_entries)}")
@@ -288,3 +304,4 @@ class InspireWriter(BaseWriter):
 
         # add_community succeeded — publish without file sync (files already uploaded above)
         self.drafts.publish(draft.id, logger)
+        return True


### PR DESCRIPTION
part of https://github.com/CERNDocumentServer/cds-rdm/issues/906
If an INSPIRE record has an EP approval number and it does not match an existing CDS record, the harvester raises an error and does not create a new one. Same if it matches a restricted record, that means they forgot to publish the internal version after the approval. If it matches a public record we update it as usual.