### PR TITLE
fix(harvester): match experiment aliases from INSPIRE

### DIFF
--- a/app_data/vocabularies/experiments.yaml
+++ b/app_data/vocabularies/experiments.yaml
@@ -201,6 +201,8 @@
   description:
     en: 'A 4pi Solid Angle Detector for the SPS used as a Proton-Antiproton Collider
       at a Centre of Mass Energy of 540 GeV'
+  props:
+    aliases: UA-001
 - id: WA98
   title:
     en: WA98
@@ -208,6 +210,7 @@
     en: 'Large Acceptance Measur. of Photons and Charged Particles in Heavy Ion Reactions'
   props:
     link: http://wa98.web.cern.ch/WA98/
+    aliases: WA-098
 - id: UA3
   title:
     en: UA3
@@ -218,6 +221,8 @@
     en: UA2
   description:
     en: 'Study of Antiproton-Proton Interactions at 630 GeV c.m. Energy'
+  props:
+    aliases: UA-002
 - id: UA5
   title:
     en: UA5
@@ -511,6 +516,7 @@
     en: 'Cryogenic Tracking Detectors'
   props:
     link: http://rd39.web.cern.ch/RD39/
+    aliases: RD-039
 - id: RD38
   title:
     en: RD38
@@ -1218,6 +1224,7 @@
       NA48 Setup'
   props:
     link: http://na48.web.cern.ch/NA48/NA48-2/NA48_2.html
+    aliases: NA-048-2
 - id: NA48/3
   title:
     en: NA48/3
@@ -1340,6 +1347,7 @@
     en: 'A New Search for numu to nutau Oscillations'
   props:
     link: http://choruswww.cern.ch/
+    aliases: WA-095
 - id: ATLAS
   title:
     en: ATLAS
@@ -2367,6 +2375,7 @@
       to 2pi Decays'
   props:
     link: http://na48.web.cern.ch/NA48/
+    aliases: NA-048
 - id: S134
   title:
     en: S134
@@ -2764,6 +2773,8 @@
     en: RD44
   description:
     en: 'GEANT 4: an Object-Oriented toolkit for simulation in HEP'
+  props:
+    aliases: RD-044
 - id: WA28
   title:
     en: WA28
@@ -3528,6 +3539,8 @@
     en: NA37
   description:
     en: 'Detailed Measurements of Structure Functions from Nucleons and Nuclei'
+  props:
+    aliases: NA-037
 - id: NP08
   title:
     en: NP08
@@ -3696,6 +3709,7 @@
       Colliders'
   props:
     link: http://rd50.web.cern.ch/RD50/
+    aliases: RD-050
 - id: RD53
   title:
     en: RD53
@@ -3856,6 +3870,8 @@
     en: WA79
   description:
     en: 'Study of Neutrino-Electron Scattering at the SPS'
+  props:
+    aliases: WA-079
 - id: WA78
   title:
     en: WA78
@@ -4773,6 +4789,7 @@
     en: 'High-Energy Neutrino Interactions'
   props:
     link: http://knobloch.home.cern.ch/knobloch/cdhs/cdhs.html
+    aliases: WA-001
 - id: ALICE
   title:
     en: ALICE
@@ -6369,6 +6386,7 @@
     en: 'Search for the Oscillation numu to nutau.'
   props:
     link: http://nomad-info.web.cern.ch/nomad-info/
+    aliases: WA-096
 - id: S87
   title:
     en: S87
@@ -6554,6 +6572,7 @@
     en: 'Proposal to Measure the Rare Decay K+ -> pi+ nu nu at the Cern SPS'
   props:
     link: http://na62.web.cern.ch/NA62/
+    aliases: NA-062
 - id: NA65
   title:
     en: NA65
@@ -7312,6 +7331,7 @@
       Flux'
   props:
     link: http://harp.web.cern.ch/harp/
+    aliases: PS-214
 - id: IS455
   title:
     en: IS455

--- a/site/cds_rdm/inspire_harvester/utils.py
+++ b/site/cds_rdm/inspire_harvester/utils.py
@@ -149,6 +149,12 @@ def get_vocabulary_exact(term, vocab_type, ctx, logger):
             if vocab_id:
                 return vocab_id
 
+        result = service.search(
+            system_identity, type=vocab_type, q=f'props.aliases.keyword:{term}'
+        )
+        if result.total == 1:
+            return list(result.hits)[0]["id"]
+
         logger.warning(
             f"Vocabulary term not found in '{vocab_type}'. | details: term={term}"
         )


### PR DESCRIPTION
Part of https://github.com/CERNDocumentServer/cds-rdm/issues/906
INSPIRE harvests sometimes send experiment names that do not match our vocabulary ids (for example WA-095 vs WA95). After the existing exact-id lookup and hyphen/uppercase fallback, the harvester now searches props.aliases and uses the result when there is exactly one hit. Aliases were added on the experiment entries that were failing in harvest logs so those INSPIRE spellings map to the matching vocab ids.