### PR TITLE
fix(preserve-permissions): add can_all permission for public records

### DIFF
--- a/site/cds_rdm/permissions.py
+++ b/site/cds_rdm/permissions.py
@@ -111,6 +111,7 @@ class CDSRDMRecordPermissionPolicy(RDMRecordPermissionPolicy):
 class CDSRDMPreservationSyncPermissionPolicy(DefaultPreservationInfoPermissionPolicy):
     """PreservationSync permission policy."""
 
+    can_all = RDMRecordPermissionPolicy.can_all
     can_read = RDMRecordPermissionPolicy.can_read + [ArchiverNotification()]
     can_create = [ArchiverNotification()]
 


### PR DESCRIPTION
## Root cause
CDSRDMPreservationSyncPermissionPolicy.can_read reused generators from RDMRecordPermissionPolicy.can_read, which include SameAs("can_all"). This is a delegating generator that at runtime does getattr(policy, "can_all") on whichever policy is active. Since CDSRDMPreservationSyncPermissionPolicy never defined can_all, this raised an AttributeError.

closes https://github.com/CERNDocumentServer/cds-rdm/issues/929