### PR TITLE
fix(harvester): handle legacy CDS recid checks before create

### DIFF
--- a/site/cds_rdm/inspire_harvester/load/matcher.py
+++ b/site/cds_rdm/inspire_harvester/load/matcher.py
@@ -10,9 +10,16 @@
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+import requests
 from invenio_access.permissions import system_identity
 from invenio_rdm_records.proxies import current_rdm_records_service
 from invenio_search.engine import dsl
+from invenio_vocabularies.datastreams.errors import WriterError
+from sqlalchemy.orm.exc import NoResultFound
+
+from cds_rdm.inspire_harvester.utils import retrieve_identifiers
+from cds_rdm.legacy.resolver import get_pid_by_legacy_recid
+from cds_rdm.schemes import generate_cds_url, legacy_cds_pattern
 
 
 @dataclass
@@ -21,6 +28,7 @@ class MatchResult:
 
     ambiguous: bool = False
     found: bool = False
+    unmigrated: bool = False
     record_pid: Optional[str] = None
     matched_ids: List[str] = field(default_factory=list)
 
@@ -29,7 +37,18 @@ class MatchResult:
 class FilterCandidate:
     """Search filter tried as part of the record-matching priority chain."""
 
-    value: Optional[str]
+    values: object = None
+
+    def __post_init__(self):
+        """Cast ``values`` to a list so callers can pass ids as-is."""
+        raw = self.values
+        if isinstance(raw, str):
+            values = [raw]
+        elif raw:
+            values = [v for v in raw if v]
+        else:
+            values = self.values
+        object.__setattr__(self, "values", values)
 
     @property
     def query(self) -> List[dsl.Q]:
@@ -44,7 +63,7 @@ class ParentMatchFilter(FilterCandidate):
     @property
     def query(self):
         """Build the parent identifier query."""
-        return [dsl.Q("term", **{"parent.id": self.value})]
+        return [dsl.Q("terms", **{"parent.id": self.values})]
 
 
 @dataclass(frozen=True)
@@ -56,7 +75,7 @@ class CDSIdentifierMatchFilter(FilterCandidate):
         """Build the legacy CDS identifier query."""
         return [
             dsl.Q("term", **{"metadata.identifiers.scheme": "cds"}),
-            dsl.Q("term", **{"metadata.identifiers.identifier": self.value}),
+            dsl.Q("terms", **{"metadata.identifiers.identifier": self.values}),
         ]
 
 
@@ -67,7 +86,7 @@ class DOIMatchFilter(FilterCandidate):
     @property
     def query(self):
         """Build the DOI query."""
-        return [dsl.Q("term", **{"pids.doi.identifier.keyword": self.value})]
+        return [dsl.Q("terms", **{"pids.doi.identifier.keyword": self.values})]
 
 
 @dataclass(frozen=True)
@@ -80,8 +99,8 @@ class InspireIdentifierMatchFilter(FilterCandidate):
         return [
             dsl.Q("term", **{"metadata.related_identifiers.scheme": "inspire"}),
             dsl.Q(
-                "term",
-                **{"metadata.related_identifiers.identifier": self.value},
+                "terms",
+                **{"metadata.related_identifiers.identifier": self.values},
             ),
         ]
 
@@ -96,8 +115,8 @@ class ArxivIdentifierMatchFilter(FilterCandidate):
         return [
             dsl.Q("term", **{"metadata.related_identifiers.scheme": "arxiv"}),
             dsl.Q(
-                "term",
-                **{"metadata.related_identifiers.identifier": self.value},
+                "terms",
+                **{"metadata.related_identifiers.identifier": self.values},
             ),
         ]
 
@@ -112,8 +131,8 @@ class ReportNumberMatchFilter(FilterCandidate):
         return [
             dsl.Q("term", **{"metadata.identifiers.scheme": "cdsrn"}),
             dsl.Q(
-                "term",
-                **{"metadata.identifiers.identifier": self.value},
+                "terms",
+                **{"metadata.identifiers.identifier": self.values},
             ),
         ]
 
@@ -128,8 +147,8 @@ class RelatedReportNumberMatchFilter(FilterCandidate):
         return [
             dsl.Q("term", **{"metadata.related_identifiers.scheme": "cdsrn"}),
             dsl.Q(
-                "term",
-                **{"metadata.related_identifiers.identifier": self.value},
+                "terms",
+                **{"metadata.related_identifiers.identifier": self.values},
             ),
             dsl.Q(
                 "term",
@@ -148,8 +167,8 @@ class ApprovalReportNumberMatchFilter(FilterCandidate):
         return [
             dsl.Q("term", **{"metadata.identifiers.scheme": "apprn"}),
             dsl.Q(
-                "term",
-                **{"metadata.identifiers.identifier": self.value},
+                "terms",
+                **{"metadata.identifiers.identifier": self.values},
             ),
         ]
 
@@ -165,20 +184,26 @@ class RecordMatcher:
         """Search for existing records using a priority-ordered filter chain."""
         entry = stream_entry.entry
         ctx = entry["_inspire_ctx"]
+
+        migrated = self.match_migrated(entry, logger)
+        if migrated.found or migrated.ambiguous or migrated.unmigrated:
+            return migrated
+
         filter_candidates = self._build_filter_priority(
             entry, inspire_id, ctx["cds_id"]
         )
         result = None
         for candidate in filter_candidates:
-            if candidate.value:
-                combined_filter = dsl.Q("bool", filter=candidate.query)
-                logger.debug(f"Searching for existing records: {candidate.query}")
-                result = current_rdm_records_service.search(
-                    self.identity, extra_filter=combined_filter
-                )
-                if result.total >= 1:
-                    logger.debug(f"Found {result.total} matching records.")
-                    break
+            if not candidate.values:
+                continue
+            combined_filter = dsl.Q("bool", filter=candidate.query)
+            logger.debug(f"Searching for existing records: {candidate.query}")
+            result = current_rdm_records_service.search(
+                self.identity, extra_filter=combined_filter
+            )
+            if result.total >= 1:
+                logger.debug(f"Found {result.total} matching records.")
+                break
 
         if result is None or result.total == 0:
             return MatchResult(found=False)
@@ -193,12 +218,78 @@ class RecordMatcher:
             found=True, record_pid=matched_ids[0], matched_ids=matched_ids
         )
 
-    def _retrieve_identifier(self, identifiers, scheme) -> Optional[str]:
-        """Retrieve identifier by scheme."""
-        return next(
-            (d["identifier"] for d in identifiers if d["scheme"] == scheme),
-            None,
+    def match_migrated(self, entry, logger):
+        """Match a migrated legacy CDS record via ``lrecid`` / old CDS status.
+
+        Returns ``False`` when the entry has no integer legacy CDS identifier.
+        """
+        identifiers = entry.get("metadata", {}).get("identifiers", [])
+        legacy_ids = [
+            cds_id
+            for cds_id in retrieve_identifiers(identifiers, "cds")
+            if legacy_cds_pattern.match(str(cds_id))
+        ]
+        matched_ids = []
+        unresolved = []
+        for cds_id in legacy_ids:
+            try:
+                parent_pid = get_pid_by_legacy_recid(str(cds_id))
+                record = current_rdm_records_service.read_latest(
+                    self.identity, id_=parent_pid.pid_value
+                )
+                logger.debug(f"Found record by legacy recid {cds_id}: {record.id}")
+                if record.id not in matched_ids:
+                    matched_ids.append(record.id)
+            except NoResultFound:
+                logger.debug(f"No lrecid in pidstore for {cds_id}.")
+                unresolved.append(cds_id)
+
+        if matched_ids:
+            if len(matched_ids) > 1:
+                return MatchResult(ambiguous=True, matched_ids=matched_ids)
+            return MatchResult(
+                found=True, record_pid=matched_ids[0], matched_ids=matched_ids
+            )
+
+        if not unresolved:
+            return MatchResult(found=False)
+
+        redirected = []
+        still_on_legacy = []
+        missing = []
+        for cds_id in unresolved:
+            response = self._get_legacy_cds(cds_id)
+            location = response.headers.get("Location", "")
+            status = response.status_code
+            if status == 404:
+                missing.append(cds_id)
+            elif status in (301, 302) and "repository.cern" in location:
+                redirected.append(cds_id)
+            elif status == 200:
+                still_on_legacy.append(cds_id)
+            else:
+                raise WriterError(
+                    "Unexpected response from old CDS. "
+                    f"| details: recid={cds_id}, status={status}"
+                )
+
+        if redirected:
+            raise WriterError(
+                "Legacy CDS record redirects to repository.cern but "
+                "lrecid is missing from pidstore. "
+                f"| details: recid={', '.join(redirected)}"
+            )
+        if still_on_legacy:
+            return MatchResult(unmigrated=True, matched_ids=still_on_legacy)
+        raise WriterError(
+            "CDS recid from INSPIRE was not found in the old CDS. "
+            f"| details: recid={', '.join(missing)}"
         )
+
+    def _get_legacy_cds(self, cds_id):
+        """Probe old CDS without following redirects."""
+        url = generate_cds_url("cds", str(cds_id))
+        return requests.head(url, allow_redirects=False, timeout=60)
 
     def _build_filter_priority(self, entry, inspire_id, cdsrdm_id):
         """Build the priority-ordered record match candidates."""
@@ -206,18 +297,19 @@ class RecordMatcher:
         identifiers = entry["metadata"].get("identifiers", [])
         related_identifiers = entry["metadata"].get("related_identifiers", [])
 
-        cds_id = self._retrieve_identifier(related_identifiers, "cds")
-        arxiv_id = self._retrieve_identifier(related_identifiers, "arxiv")
-        report_number = self._retrieve_identifier(identifiers, "cdsrn")
-        related_report_number = self._retrieve_identifier(related_identifiers, "cdsrn")
-        approval_report_number = self._retrieve_identifier(identifiers, "apprn")
         return [
-            ParentMatchFilter(value=cdsrdm_id),
-            CDSIdentifierMatchFilter(value=cds_id),
-            DOIMatchFilter(value=doi),
-            InspireIdentifierMatchFilter(value=inspire_id),
-            ArxivIdentifierMatchFilter(value=arxiv_id),
-            ReportNumberMatchFilter(value=report_number),
-            ApprovalReportNumberMatchFilter(value=approval_report_number),
-            RelatedReportNumberMatchFilter(value=related_report_number),
+            ParentMatchFilter(values=cdsrdm_id),
+            CDSIdentifierMatchFilter(values=retrieve_identifiers(identifiers, "cds")),
+            DOIMatchFilter(values=doi),
+            InspireIdentifierMatchFilter(values=inspire_id),
+            ArxivIdentifierMatchFilter(
+                values=retrieve_identifiers(related_identifiers, "arxiv")
+            ),
+            ReportNumberMatchFilter(values=retrieve_identifiers(identifiers, "cdsrn")),
+            ApprovalReportNumberMatchFilter(
+                values=retrieve_identifiers(identifiers, "apprn")
+            ),
+            RelatedReportNumberMatchFilter(
+                values=retrieve_identifiers(related_identifiers, "cdsrn")
+            ),
         ]

--- a/site/cds_rdm/inspire_harvester/load/validator.py
+++ b/site/cds_rdm/inspire_harvester/load/validator.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 
 from flask import current_app
 
+from cds_rdm.inspire_harvester.utils import retrieve_identifiers
+
 
 @dataclass(frozen=True)
 class ValidationRule(ABC):
@@ -29,16 +31,18 @@ class EpApprovalCreateRule(ValidationRule):
 
     def check(self, stream_entry, *, record=None, record_pid=None, matcher=None):
         """Return an error if ``apprn`` is present on create."""
-        apprn = matcher._retrieve_identifier(
-            stream_entry.entry.get("metadata", {}).get("identifiers", []),
-            "apprn",
+        apprns = list(
+            retrieve_identifiers(
+                stream_entry.entry.get("metadata", {}).get("identifiers", []),
+                "apprn",
+            )
         )
-        if not apprn:
+        if not apprns:
             return None
         return (
             "EP approval number did not match an existing record - EP approval "
             "numbers can't be assigned outside CDS publishing workflow. "
-            f"| details: apprn={apprn}"
+            f"| details: apprn={', '.join(apprns)}"
         )
 
 
@@ -64,18 +68,20 @@ class EpApprovalUpdateRule(ValidationRule):
 
     def check(self, stream_entry, *, record=None, record_pid=None, matcher=None):
         """Return an error if ``apprn`` matches a restricted CDS record."""
-        apprn = matcher._retrieve_identifier(
-            stream_entry.entry.get("metadata", {}).get("identifiers", []),
-            "apprn",
+        apprns = list(
+            retrieve_identifiers(
+                stream_entry.entry.get("metadata", {}).get("identifiers", []),
+                "apprn",
+            )
         )
-        if not apprn:
+        if not apprns:
             return None
         if record.get("access", {}).get("record") != "restricted":
             return None
         return (
             "EP approval number matched a restricted record - record must be "
             "public to be updated by the harvester "
-            f"| details: apprn={apprn}, cds_id={record_pid}"
+            f"| details: apprn={', '.join(apprns)}, cds_id={record_pid}"
         )
 
 

--- a/site/cds_rdm/inspire_harvester/utils.py
+++ b/site/cds_rdm/inspire_harvester/utils.py
@@ -15,6 +15,13 @@ from opensearchpy import RequestError
 from sqlalchemy.exc import NoResultFound
 
 
+def retrieve_identifiers(identifiers, scheme):
+    """Yield identifier values for the given scheme."""
+    for ident in identifiers or []:
+        if ident.get("scheme") == scheme and ident.get("identifier"):
+            yield ident["identifier"]
+
+
 def compare_metadata(a, b):
     """Compare metadata based on id key only."""
     # If both are dicts

--- a/site/cds_rdm/inspire_harvester/writer.py
+++ b/site/cds_rdm/inspire_harvester/writer.py
@@ -115,6 +115,13 @@ class InspireWriter(BaseWriter):
                 return None
             return "update"
 
+        elif match_result.unmigrated:
+            logger.warning(
+                "Record is still in the old CDS, skipping harvest. "
+                f"| details: recid={', '.join(match_result.matched_ids)}"
+            )
+            return None
+
         else:
             if not self._create_record(stream_entry):
                 return None

--- a/site/tests/inspire_harvester/data/completely_new_inspire_rec.json
+++ b/site/tests/inspire_harvester/data/completely_new_inspire_rec.json
@@ -204,12 +204,7 @@
               "source": "curator"
             }
           ],
-          "external_system_identifiers": [
-            {
-              "value": "2946564",
-              "schema": "CDS"
-            }
-          ]
+          "external_system_identifiers": []
         },
         "updated": "2025-10-27T08:27:39.941638+00:00",
         "links": {

--- a/site/tests/inspire_harvester/data/inspire_response_15_records_page_1.json
+++ b/site/tests/inspire_harvester/data/inspire_response_15_records_page_1.json
@@ -197,12 +197,7 @@
                             "value": "20.500.11850/674635"
                         }
                     ],
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2918365"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "facet_author_name": [
                         "1671459_Amanda Seyfried"
                     ],
@@ -447,12 +442,7 @@
                             "value": "11392/2549512"
                         }
                     ],
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2918364"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "facet_author_name": [
                         "2172745_Johnny Depp"
                     ],
@@ -788,12 +778,7 @@
                             "title": "Search for axion-like particles in ultraperipheral PbPb collisions at the LHCb experiment"
                         }
                     ],
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2918366"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "facet_author_name": [
                         "2843421_Jamie Lee Curtis"
                     ],
@@ -1100,12 +1085,7 @@
                     "preprint_date": "2019-06",
                     "author_count": 1,
                     "earliest_date": "2019-06",
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2717810"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "facet_author_name": [
                         "1727473_James Paul McCartney"
                     ],
@@ -1380,12 +1360,7 @@
                             "title": "Estudo das correlações cinemáticas em topologias de difração dura no contexto do CMS/LHC"
                         }
                     ],
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2633876"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "title_translations": [
                         {
                             "language": "en",
@@ -1636,12 +1611,7 @@
                             "title": "Medición del tiempo de vida del K+ en el experimento NA62"
                         }
                     ],
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2918367"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "facet_author_name": [
                         "2802970_Diego Armando Maradona Franco"
                     ],
@@ -1879,12 +1849,7 @@
                     "legacy_creation_date": "2016-04-27",
                     "author_count": 1,
                     "earliest_date": "2014-05-05",
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2152014"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "facet_author_name": [
                         "1424171_Timothee Chalamet"
                     ],
@@ -2083,12 +2048,7 @@
                             "title": "Medición de B(K+→e+νe)/B(K+→π0e+νe)"
                         }
                     ],
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2918965"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "facet_author_name": [
                         "2854457_Emilio Gaviria"
                     ],
@@ -2350,12 +2310,7 @@
                             "value": "10831/33500"
                         }
                     ],
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2273649"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "facet_author_name": [
                         "1249779_Laszlo Olah"
                     ],
@@ -2720,12 +2675,7 @@
                     "legacy_creation_date": "2018-01-11",
                     "author_count": 1,
                     "earliest_date": "2016-07-08",
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2300280"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "facet_author_name": [
                         "1246082_Tom Cruise"
                     ],

--- a/site/tests/inspire_harvester/data/inspire_response_15_records_page_2.json
+++ b/site/tests/inspire_harvester/data/inspire_response_15_records_page_2.json
@@ -202,12 +202,7 @@
                     "number_of_pages": 171,
                     "author_count": 1,
                     "earliest_date": "2024-05-31",
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2918368"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "facet_author_name": [
                         "1858329_Joanna Hathaway"
                     ],
@@ -530,12 +525,7 @@
                             "value": "20.500.11956/195353"
                         }
                     ],
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2918370"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "facet_author_name": [
                         "1907813_Will Smith"
                     ],
@@ -852,12 +842,7 @@
                             "title": "Fragmentation through Heavy and Light-flavor Measurements with the LHC ALICE Experiment"
                         }
                     ],
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2918369"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "facet_author_name": [
                         "1695594_Natalie Portman"
                     ],
@@ -1112,12 +1097,7 @@
                             "value": "11571/1476531"
                         }
                     ],
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2889401"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "facet_author_name": [
                         "1757334_Chiara Aime"
                     ],
@@ -1411,12 +1391,7 @@
                             "value": "1983/58b7ed36-8b9f-4d4d-9bcd-c1cabcc532d4"
                         }
                     ],
-                    "external_system_identifiers": [
-                        {
-                            "schema": "CDS",
-                            "value": "2918371"
-                        }
-                    ],
+                    "external_system_identifiers": [],
                     "facet_author_name": [
                         "1802029_Ryan Reynolds"
                     ],

--- a/site/tests/inspire_harvester/test_harvester_job.py
+++ b/site/tests/inspire_harvester/test_harvester_job.py
@@ -78,9 +78,6 @@ expected_result_1 = {
         "title": "Fragmentation through Heavy and Light-flavor Measurements with the LHC ALICE Experiment",
         "publication_date": "2024",
         "languages": [{"id": "eng", "title": {"en": "English", "da": "Engelsk"}}],
-        "identifiers": [
-            {"identifier": "2918369", "scheme": "cds"},
-        ],
         "related_identifiers": [
             {
                 "identifier": "2840463",
@@ -180,9 +177,6 @@ expected_result_2 = {
             {"subject": "charged particle: irradiation"},
             {"subject": "attenuation"},
             {"subject": "data analysis method"},
-        ],
-        "identifiers": [
-            {"identifier": "2152014", "scheme": "cds"},
         ],
         "related_identifiers": [
             {
@@ -294,9 +288,6 @@ expected_result_3 = {
         "title": "Medición del tiempo de vida del K+ en el experimento NA62",
         "publication_date": "2024-05",
         "languages": [{"id": "spa", "title": {"en": "Spanish"}}],
-        "identifiers": [
-            {"identifier": "2918367", "scheme": "cds"},
-        ],
         "related_identifiers": [
             {
                 "identifier": "2802969",

--- a/site/tests/inspire_harvester/test_matcher.py
+++ b/site/tests/inspire_harvester/test_matcher.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 CERN.
+#
+# CDS-RDM is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+"""INSPIRE harvester matcher tests."""
+from unittest.mock import Mock, patch
+
+import pytest
+from invenio_vocabularies.datastreams.errors import WriterError
+from sqlalchemy.orm.exc import NoResultFound
+
+from cds_rdm.inspire_harvester.load.matcher import RecordMatcher
+
+from .utils import legacy_entry
+
+
+@patch("cds_rdm.inspire_harvester.load.matcher.RecordMatcher._get_legacy_cds")
+@patch("cds_rdm.inspire_harvester.load.matcher.current_rdm_records_service.search")
+@patch("cds_rdm.inspire_harvester.load.matcher.get_pid_by_legacy_recid")
+def test_matcher_skips_fallback_search_when_legacy_pidstore_lookup_misses(
+    mock_get_pid, mock_search, mock_get_legacy, running_app
+):
+    """Legacy recid pidstore miss probes old CDS and skips the search-filter chain."""
+    matcher = RecordMatcher()
+    logger = Mock()
+    stream_entry = legacy_entry("2633876")
+    mock_get_pid.side_effect = NoResultFound()
+    mock_get_legacy.return_value = Mock(status_code=200, headers={})
+
+    result = matcher.match(stream_entry, inspire_id="111", logger=logger)
+
+    assert result.unmigrated is True
+    assert result.found is False
+    assert result.ambiguous is False
+    mock_search.assert_not_called()
+    mock_get_legacy.assert_called_once_with("2633876")
+
+
+@patch("cds_rdm.inspire_harvester.load.matcher.current_rdm_records_service.read_latest")
+@patch("cds_rdm.inspire_harvester.load.matcher.get_pid_by_legacy_recid")
+def test_matcher_finds_record_by_legacy_recid(
+    mock_get_pid, mock_read_latest, running_app
+):
+    """Pidstore hit on the CDS recid updates that record."""
+    matcher = RecordMatcher()
+    logger = Mock()
+    stream_entry = legacy_entry("2765541")
+    mock_get_pid.return_value = Mock(pid_value="parent-1")
+    mock_read_latest.return_value = Mock(id="rec-1")
+
+    result = matcher.match(stream_entry, inspire_id="111", logger=logger)
+
+    assert result.found is True
+    assert result.record_pid == "rec-1"
+
+
+@patch("cds_rdm.inspire_harvester.load.matcher.current_rdm_records_service.read_latest")
+@patch("cds_rdm.inspire_harvester.load.matcher.get_pid_by_legacy_recid")
+def test_matcher_tries_each_legacy_cds_id_until_pidstore_hits(
+    mock_get_pid, mock_read_latest, running_app
+):
+    """A later CDS recid should still match when an earlier one is missing."""
+    matcher = RecordMatcher()
+    logger = Mock()
+    stream_entry = legacy_entry("2798711", "2765541")
+    mock_get_pid.side_effect = [NoResultFound(), Mock(pid_value="parent-1")]
+    mock_read_latest.return_value = Mock(id="rec-1")
+
+    result = matcher.match(stream_entry, inspire_id="111", logger=logger)
+
+    assert result.found is True
+    assert result.record_pid == "rec-1"
+    assert mock_get_pid.call_count == 2
+
+
+@patch("cds_rdm.inspire_harvester.load.matcher.current_rdm_records_service.search")
+@patch("cds_rdm.inspire_harvester.load.matcher.current_rdm_records_service.read_latest")
+@patch("cds_rdm.inspire_harvester.load.matcher.get_pid_by_legacy_recid")
+def test_matcher_is_ambiguous_when_legacy_ids_hit_different_records(
+    mock_get_pid, mock_read_latest, mock_search, running_app
+):
+    """Two CDS recids pointing at different records should not pick one to update."""
+    matcher = RecordMatcher()
+    logger = Mock()
+    stream_entry = legacy_entry("2765541", "2798711")
+    mock_get_pid.side_effect = [Mock(pid_value="parent-1"), Mock(pid_value="parent-2")]
+    mock_read_latest.side_effect = [Mock(id="rec-1"), Mock(id="rec-2")]
+
+    result = matcher.match(stream_entry, inspire_id="111", logger=logger)
+
+    assert result.ambiguous is True
+    assert result.found is False
+    assert result.matched_ids == ["rec-1", "rec-2"]
+    mock_search.assert_not_called()
+
+
+@patch("cds_rdm.inspire_harvester.load.matcher.RecordMatcher._get_legacy_cds")
+@patch("cds_rdm.inspire_harvester.load.matcher.get_pid_by_legacy_recid")
+def test_matcher_skips_when_one_of_two_legacy_ids_is_still_on_cds(
+    mock_get_pid, mock_get_legacy, running_app
+):
+    """A later CDS recid still on old CDS should skip even if an earlier one 404s."""
+    matcher = RecordMatcher()
+    logger = Mock()
+    stream_entry = legacy_entry("2798711", "2765541")
+    mock_get_pid.side_effect = NoResultFound()
+    mock_get_legacy.side_effect = [
+        Mock(status_code=404, headers={}),
+        Mock(status_code=200, headers={}),
+    ]
+
+    result = matcher.match(stream_entry, inspire_id="111", logger=logger)
+
+    assert result.unmigrated is True
+    assert result.matched_ids == ["2765541"]
+    assert mock_get_legacy.call_count == 2
+
+
+@patch("cds_rdm.inspire_harvester.load.matcher.RecordMatcher._get_legacy_cds")
+@patch("cds_rdm.inspire_harvester.load.matcher.get_pid_by_legacy_recid")
+def test_matcher_errors_when_one_of_two_legacy_ids_redirects_to_rdm(
+    mock_get_pid, mock_get_legacy, running_app
+):
+    """A redirected CDS recid should error even if another id is still on old CDS."""
+    matcher = RecordMatcher()
+    logger = Mock()
+    stream_entry = legacy_entry("2765541", "2798711")
+    mock_get_pid.side_effect = NoResultFound()
+    mock_get_legacy.side_effect = [
+        Mock(status_code=200, headers={}),
+        Mock(
+            status_code=302,
+            headers={"Location": "https://repository.cern/records/abcde-fghij"},
+        ),
+    ]
+
+    with pytest.raises(WriterError, match="lrecid is missing from pidstore"):
+        matcher.match(stream_entry, inspire_id="111", logger=logger)
+
+
+@patch("cds_rdm.inspire_harvester.load.matcher.RecordMatcher._get_legacy_cds")
+@patch("cds_rdm.inspire_harvester.load.matcher.get_pid_by_legacy_recid")
+def test_matcher_errors_when_all_legacy_ids_are_missing_on_cds(
+    mock_get_pid, mock_get_legacy, running_app
+):
+    """All unresolved CDS recids 404ing should error, not create."""
+    matcher = RecordMatcher()
+    logger = Mock()
+    stream_entry = legacy_entry("2798711", "2765541")
+    mock_get_pid.side_effect = NoResultFound()
+    mock_get_legacy.return_value = Mock(status_code=404, headers={})
+
+    with pytest.raises(WriterError, match="was not found in the old CDS"):
+        matcher.match(stream_entry, inspire_id="111", logger=logger)
+
+    assert mock_get_legacy.call_count == 2
+
+
+@patch("cds_rdm.inspire_harvester.load.matcher.RecordMatcher._get_legacy_cds")
+@patch("cds_rdm.inspire_harvester.load.matcher.get_pid_by_legacy_recid")
+def test_matcher_errors_on_unexpected_legacy_cds_status(
+    mock_get_pid, mock_get_legacy, running_app
+):
+    """Unexpected old-CDS responses should fail loudly."""
+    matcher = RecordMatcher()
+    logger = Mock()
+    stream_entry = legacy_entry("2633876")
+    mock_get_pid.side_effect = NoResultFound()
+    mock_get_legacy.return_value = Mock(status_code=500, headers={})
+
+    with pytest.raises(WriterError, match="Unexpected response from old CDS"):
+        matcher.match(stream_entry, inspire_id="111", logger=logger)

--- a/site/tests/inspire_harvester/test_metadata_only_new_version.py
+++ b/site/tests/inspire_harvester/test_metadata_only_new_version.py
@@ -15,13 +15,13 @@ from invenio_rdm_records.records import RDMRecord
 
 from ..conftest import minimal_record_with_files
 from ..utils import add_file_to_draft
-from .utils import mock_requests_get, run_harvester_mock
+from .utils import add_legacy_recid, mock_requests_get, run_harvester_mock
 
 DATA_DIR = Path(__file__).parent / "data"
 
 
 def test_update_no_CDS_DOI_from_metadata_only_to_files(
-    running_app, location, scientific_community, datastream_config, minimal_record
+    running_app, location, scientific_community, datastream_config, minimal_record, add_pid
 ):
     """Test update record, originally no files, adding files to the same version."""
     service = current_rdm_records_service
@@ -39,6 +39,7 @@ def test_update_no_CDS_DOI_from_metadata_only_to_files(
 
     draft = service.create(system_identity, minimal_record)
     record = current_rdm_records_service.publish(system_identity, draft.id)
+    add_legacy_recid(add_pid, record, "2765541")
 
     RDMRecord.index.refresh()
     with open(

--- a/site/tests/inspire_harvester/test_multiple_document_types_external.py
+++ b/site/tests/inspire_harvester/test_multiple_document_types_external.py
@@ -15,7 +15,7 @@ from invenio_rdm_records.records import RDMRecord
 
 from ..conftest import minimal_record_with_files
 from ..utils import add_file_to_draft
-from .utils import mock_requests_get, run_harvester_mock
+from .utils import add_legacy_recid, mock_requests_get, run_harvester_mock
 
 DATA_DIR = Path(__file__).parent / "data"
 
@@ -57,9 +57,7 @@ def test_new_non_CDS_record(
             },
         }
     ]
-    assert created_record["metadata"]["identifiers"] == [
-        {"scheme": "cds", "identifier": "2946564"}
-    ]
+    assert "identifiers" not in created_record["metadata"]
     assert created_record["pids"]["doi"] == {
         "identifier": "10.1051/epjconf/202533701165",
         "provider": "external",
@@ -72,6 +70,7 @@ def test_update_no_CDS_DOI_multiple_doc_types(
     scientific_community,
     datastream_config,
     minimal_record_with_files,
+    add_pid,
 ):
     service = current_rdm_records_service
 
@@ -91,6 +90,7 @@ def test_update_no_CDS_DOI_multiple_doc_types(
     draft = service.create(system_identity, minimal_record_with_files)
     add_file_to_draft(service.draft_files, system_identity, draft, "test")
     record = current_rdm_records_service.publish(system_identity, draft.id)
+    add_legacy_recid(add_pid, record, "2765541")
 
     RDMRecord.index.refresh()
     with open(

--- a/site/tests/inspire_harvester/test_transformer.py
+++ b/site/tests/inspire_harvester/test_transformer.py
@@ -334,11 +334,11 @@ def test_matcher_includes_approval_report_number(running_app):
         },
     }
     candidates = RecordMatcher()._build_filter_priority(entry, "12345", None)
-    by_type = {type(c): c for c in candidates if c.value}
+    by_type = {type(c): c for c in candidates if c.values}
 
-    assert by_type[ReportNumberMatchFilter].value == "CERN-THESIS-2010-364"
-    assert by_type[RelatedReportNumberMatchFilter].value == "DESY-24-001"
-    assert by_type[ApprovalReportNumberMatchFilter].value == "CERN-EP-2026-001"
+    assert by_type[ReportNumberMatchFilter].values == ["CERN-THESIS-2010-364"]
+    assert by_type[RelatedReportNumberMatchFilter].values == ["DESY-24-001"]
+    assert by_type[ApprovalReportNumberMatchFilter].values == ["CERN-EP-2026-001"]
     assert any(
         q.to_dict() == {"term": {"metadata.identifiers.scheme": "apprn"}}
         for q in by_type[ApprovalReportNumberMatchFilter].query
@@ -349,7 +349,7 @@ def test_matcher_includes_approval_report_number(running_app):
         for q in by_type[RelatedReportNumberMatchFilter].query
     )
 
-    valued = [type(c) for c in candidates if c.value]
+    valued = [type(c) for c in candidates if c.values]
     assert valued.index(ApprovalReportNumberMatchFilter) < valued.index(
         RelatedReportNumberMatchFilter
     )

--- a/site/tests/inspire_harvester/test_update_create_CDS_records.py
+++ b/site/tests/inspire_harvester/test_update_create_CDS_records.py
@@ -12,7 +12,7 @@ from cds_rdm.legacy.resolver import get_record_by_version
 
 from ..conftest import minimal_record_with_files
 from ..utils import add_file_to_draft
-from .utils import mock_requests_get, run_harvester_mock
+from .utils import add_legacy_recid, mock_requests_get, run_harvester_mock
 
 DATA_DIR = Path(__file__).parent / "data"
 
@@ -26,6 +26,13 @@ def test_CDS_DOI_create_record_fails(
             "r",
     ) as f:
         new_record = json.load(f)
+        new_record["hits"]["hits"][0]["metadata"]["external_system_identifiers"] = [
+            ident
+            for ident in new_record["hits"]["hits"][0]["metadata"].get(
+                "external_system_identifiers", []
+            )
+            if ident.get("schema") != "CDS"
+        ]
 
     mock_record = partial(mock_requests_get, mock_content=new_record)
     run_harvester_mock(datastream_config, mock_record)
@@ -48,6 +55,7 @@ def test_update_record_with_CDS_DOI_one_doc_type(
         scientific_community,
         minimal_record_with_files,
         datastream_config,
+        add_pid,
 ):
     """Test update record with CDS DOI - matched record.
 
@@ -64,6 +72,7 @@ def test_update_record_with_CDS_DOI_one_doc_type(
     service = current_rdm_records_service
     add_file_to_draft(service.draft_files, system_identity, draft, "test")
     record = current_rdm_records_service.publish(system_identity, draft.id)
+    add_legacy_recid(add_pid, record, "2310827")
 
     with open(
             DATA_DIR / "record_with_cds_DOI.json",
@@ -115,6 +124,7 @@ def test_update_record_with_CDS_DOI_multiple_doc_types(
         scientific_community,
         existing_fcc_record,
         datastream_config,
+        add_pid,
 ):
     """Test update record with CDS DOI - matched record with multiple document types.
 
@@ -145,6 +155,7 @@ def test_update_record_with_CDS_DOI_multiple_doc_types(
         content=content,
     )
     record = current_rdm_records_service.publish(system_identity, draft.id)
+    add_legacy_recid(add_pid, record, "2882312")
     cds_doi = record["pids"]["doi"]["identifier"]
 
     with open(

--- a/site/tests/inspire_harvester/test_writer.py
+++ b/site/tests/inspire_harvester/test_writer.py
@@ -8,16 +8,20 @@
 """ISNPIRE harvester writer tests."""
 from copy import deepcopy
 from io import BytesIO
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from invenio_access.permissions import system_identity
 from invenio_rdm_records.proxies import current_rdm_records, current_rdm_records_service
 from invenio_rdm_records.records.api import RDMRecord
 from invenio_vocabularies.datastreams import StreamEntry
+from invenio_vocabularies.datastreams.errors import WriterError
 
 from cds_rdm.inspire_harvester.load.files import FileSynchronizer
+from cds_rdm.inspire_harvester.load.matcher import MatchResult
 from cds_rdm.inspire_harvester.writer import InspireWriter
+
+from .utils import legacy_entry
 
 
 def _cleanup_record(recid):
@@ -186,6 +190,57 @@ def test_writer_1_rec_1_file(
     assert "source_url" not in files["entries"]["fulltext.pdf"]
 
     _cleanup_record(record["id"])
+
+
+def test_writer_skips_record_still_on_legacy_cds(running_app, scientific_community):
+    """Legacy CDS records still on old CDS should be skipped."""
+    writer = InspireWriter()
+    writer.matcher.match = Mock(
+        return_value=MatchResult(unmigrated=True, matched_ids=["2633876"])
+    )
+    writer._create_record = Mock()
+
+    result = writer.write(legacy_entry("2633876"))
+
+    writer._create_record.assert_not_called()
+    assert result.op_type is None
+
+
+def test_writer_errors_when_legacy_recid_is_unknown(running_app, scientific_community):
+    """Unknown legacy CDS identifiers should raise an error."""
+    writer = InspireWriter()
+    writer.matcher.match = Mock(
+        side_effect=WriterError(
+            "CDS recid from INSPIRE was not found in the old CDS. | details: recid=999"
+        )
+    )
+    writer._create_record = Mock()
+
+    result = writer.write(legacy_entry("999"))
+
+    writer._create_record.assert_not_called()
+    assert result.errors
+    assert "was not found in the old CDS" in result.errors[0]
+
+
+def test_writer_errors_when_pidstore_missed_a_migrated_record(
+    running_app, scientific_community
+):
+    """Redirected legacy CDS records should expose missing lrecid minting."""
+    writer = InspireWriter()
+    writer.matcher.match = Mock(
+        side_effect=WriterError(
+            "Legacy CDS record redirects to repository.cern but "
+            "lrecid is missing from pidstore. | details: recid=2633876"
+        )
+    )
+    writer._create_record = Mock()
+
+    result = writer.write(legacy_entry("2633876"))
+
+    writer._create_record.assert_not_called()
+    assert result.errors
+    assert "lrecid is missing from pidstore" in result.errors[0]
 
 
 def test_writer_1_rec_1_file_failed(

--- a/site/tests/inspire_harvester/utils.py
+++ b/site/tests/inspire_harvester/utils.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from celery import current_app
+from invenio_pidstore.models import PersistentIdentifier
+from invenio_vocabularies.datastreams import StreamEntry
 from invenio_vocabularies.services.tasks import process_datastream
 
 DATA_DIR = Path(__file__).parent / "data"
@@ -48,8 +50,44 @@ def mock_head(url, allow_redirects=True):
     return response
 
 
+def legacy_entry(*cds_ids):
+    """Build a minimal transformed entry with legacy CDS identifier(s)."""
+    cds_ids = cds_ids or ("111",)
+    return StreamEntry(
+        {
+            "id": "111",
+            "metadata": {
+                "title": "Test",
+                "resource_type": {"id": "publication-article"},
+                "identifiers": [
+                    {"scheme": "cds", "identifier": cds_id} for cds_id in cds_ids
+                ],
+            },
+            "files": {"enabled": False},
+            "parent": {"access": {"owned_by": {"user": 2}}},
+            "access": {"record": "public", "files": "public"},
+            "_inspire_ctx": {"cds_id": cds_ids[0], "versions": []},
+        }
+    )
+
+
+def add_legacy_recid(add_pid, record, recid):
+    """Mint lrecid on the record parent (same as tests/legacy/test_redirector.py)."""
+    parent = record._record.parent
+    parent_pid = PersistentIdentifier.query.filter_by(
+        pid_value=parent.pid.pid_value, pid_type="recid"
+    ).one()
+    add_pid(
+        pid_type="lrecid",
+        pid_value=str(recid),
+        object_uuid=parent_pid.object_uuid,
+    )
+
+
 def run_harvester_mock(datastream_cfg, mock_content_function):
     """Process datastream."""
+    legacy_cds_response = Mock(status_code=200)
+    legacy_cds_response.headers = {}
     with (
         patch(
             "cds_rdm.inspire_harvester.reader.requests.get",
@@ -63,6 +101,10 @@ def run_harvester_mock(datastream_cfg, mock_content_function):
             "cds_rdm.inspire_harvester.load.files.requests.head",
             side_effect=mock_head,
         ) as mock3,
+        patch(
+            "cds_rdm.inspire_harvester.load.matcher.RecordMatcher._get_legacy_cds",
+            return_value=legacy_cds_response,
+        ),
     ):
         process_datastream(config=datastream_cfg["config"])
         tasks = current_app.control.inspect()


### PR DESCRIPTION
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/907
This PR changes how the INSPIRE harvester handles records with a legacy CDS recid and avoids duplicates between old CDS and CDS-RDM. If the incoming record has an integer legacy recid, we first check pidstore and update when it is found. If it is not found, we check old CDS directly. We raise an error when it redirects to repository.cern or returns 404. We skip with a warning when the record is still only in legacy. If there is no legacy recid in the incoming record, the existing matching flow stays the same. If INSPIRE sends more than one CDS recid (merged records keep both), we check each in pidstore and on old CDS. Two different pidstore hits are treated as multiple records match.