### PR TITLE
fix(harvester): hide system publishes from curator reports

### DIFF
--- a/site/cds_rdm/assets/semantic-ui/js/cds_rdm/administration/harvesterReports/SearchBar.js
+++ b/site/cds_rdm/assets/semantic-ui/js/cds_rdm/administration/harvesterReports/SearchBar.js
@@ -19,10 +19,7 @@ import {
 import { DownloadButton } from "./DownloadButton";
 import PropTypes from "prop-types";
 
-const hiddenParams = [
-  ["action", "record.publish"],
-  ["user_id", "system"],
-];
+const hiddenParams = [["action", "record.publish"]];
 
 /**
  * Custom SearchBar component with run selector

--- a/site/cds_rdm/generators.py
+++ b/site/cds_rdm/generators.py
@@ -144,17 +144,15 @@ class HarvesterCurator(Generator):
         return [harvester_admin_access_action]
 
     def query_filter(self, identity=None, **kwargs):
-        """Filter to harvester and legacy system publish audit logs."""
+        """Filter to dedicated harvester user publish audit logs."""
         if identity and Permission(harvester_admin_access_action).allows(identity):
-            user_ids = ["system"]
             harvester_user_id = _harvester_user_id()
-            if harvester_user_id is not None:
-                user_ids.append(harvester_user_id)
-
+            if harvester_user_id is None:
+                return []
             return dsl.Q(
                 "bool",
                 must=[
-                    dsl.Q("terms", **{"user.id": user_ids}),
+                    dsl.Q("term", **{"user.id": harvester_user_id}),
                     dsl.Q("term", action="record.publish"),
                 ],
             )

--- a/site/tests/test_permissions.py
+++ b/site/tests/test_permissions.py
@@ -50,7 +50,7 @@ def test_archiver_permissions(
             {
                 "bool": {
                     "must": [
-                        {"terms": {"user.id": ["system"]}},
+                        {"term": {"user.id": "6"}},
                         {"term": {"action": "record.publish"}},
                     ]
                 }
@@ -60,7 +60,7 @@ def test_archiver_permissions(
     ],
 )
 def test_harvester_curator_permissions(monkeypatch, provides, expected_filter):
-    """Harvester permissions use the action need and filter system/harvester logs."""
+    """Harvester reports only include publishes by the dedicated harvester user."""
     monkeypatch.setattr(
         generators,
         "Permission",
@@ -68,11 +68,7 @@ def test_harvester_curator_permissions(monkeypatch, provides, expected_filter):
             allows=lambda i: harvester_admin_access_action in i.provides
         ),
     )
-    monkeypatch.setattr(
-        generators,
-        "current_app",
-        SimpleNamespace(config={"CDS_HARVESTER_USER_EMAIL": None}),
-    )
+    monkeypatch.setattr(generators, "_harvester_user_id", lambda: "6")
 
     assert HarvesterCurator().needs() == [harvester_admin_access_action]
 


### PR DESCRIPTION
Harvester Reports were still including system publishes (the old identity) as well as the dedicated harvester user, so curators could see system harvests. This limits the curator audit-log filter and the reports search to publishes by the configured harvester user only.