### PR TITLE
change(experiments): add SHINE alias for NA61

### DIFF
--- a/app_data/vocabularies/experiments.yaml
+++ b/app_data/vocabularies/experiments.yaml
@@ -2119,6 +2119,7 @@
       at the CERN SPS'
   props:
     link: https://shine.web.cern.ch/
+    aliases: SHINE NA61
 - id: EMU10
   title:
     en: EMU10


### PR DESCRIPTION
Closes https://github.com/cERNDocumentServer/cds-migrator-kit/issues/494

Added an alias for the SHINE experiment. These aliases are already supported by the [INSPIRE harvester ](https://github.com/CERNDocumentServer/cds-rdm/blob/a874bd7636805b609c84188068215d00a56f96bf/site/cds_rdm/inspire_harvester/utils.py#L162) but I think maybe not by the migrator kit. I will check and update the code as needed, since having alternate names for experiments seems to be a normal use case (the greybook also mentions aliases for some experiments).