### PR TITLE
fix(harvester): do not map ISBN to imprint

### DIFF
--- a/site/cds_rdm/inspire_harvester/transform/mappers/custom_fields.py
+++ b/site/cds_rdm/inspire_harvester/transform/mappers/custom_fields.py
@@ -9,8 +9,6 @@
 
 from dataclasses import dataclass
 
-from idutils.normalizers import normalize_isbn
-
 from cds_rdm.inspire_harvester.transform.mappers.mapper import MapperBase
 from cds_rdm.inspire_harvester.utils import get_vocabulary_exact
 
@@ -26,28 +24,8 @@ class ImprintMapper(MapperBase):
         src_metadata = src_record.get("metadata", {})
         imprints = src_metadata.get("imprints", [])
         imprint = imprints[0] if imprints else None
-        isbns = src_metadata.get("isbns", [])
-
-        online_isbns = []
-        for isbn in isbns:
-            value = isbn.get("value")
-            valid_isbn = normalize_isbn(value)
-            if not valid_isbn:
-                ctx.errors.append(f"Invalid ISBN. | details: value={value}")
-            else:
-                if isbn.get("medium") == "online":
-                    online_isbns.append(valid_isbn)
-
-        if len(online_isbns) > 1:
-            ctx.errors.append(
-                "More than one electronic ISBN found. "
-                f"| details: online_isbns={online_isbns}"
-            )
 
         place = imprint.get("place") if imprint else None
-
-        # TODO this is true only for thesis
-        isbn = online_isbns[0] if online_isbns else None
         editions = src_metadata.get("editions", [])
         if editions:
             ctx.errors.append(
@@ -58,8 +36,6 @@ class ImprintMapper(MapperBase):
         out = {}
         if place:
             out["place"] = place
-        if isbn:
-            out["isbn"] = isbn
         return out
 
 

--- a/site/tests/inspire_harvester/test_transformer.py
+++ b/site/tests/inspire_harvester/test_transformer.py
@@ -1210,27 +1210,6 @@ def test_transform_imprint_place(running_app):
     assert result["place"] == "Geneva"
 
 
-def test_transform_imprint_place_with_isbn(running_app):
-    """Test ImprintMapper with ISBN."""
-    src_metadata = {
-        "imprints": [{"place": "New York", "publisher": "Springer"}],
-        "isbns": [{"value": "978-3-16-148410-0", "medium": "online"}],
-        "control_number": 12345,
-    }
-    ctx = MetadataSerializationContext(
-        resource_type=ResourceType.OTHER, inspire_id="12345"
-    )
-    logger = Logger(inspire_id="12345")
-    mapper = ImprintMapper()
-    src_record = {"metadata": src_metadata, "created": "2023-01-01"}
-
-    result = mapper.map_value(src_record, ctx, logger)
-
-    assert "place" in result
-    assert result["place"] == "New York"
-    assert result["isbn"] == "978-3-16-148410-0"
-
-
 def test_transform_imprint_place_no_imprints(running_app):
     """Test ImprintMapper when no imprints are present."""
     src_metadata = {


### PR DESCRIPTION
closes https://github.com/CERNDocumentServer/cds-rdm/issues/457
ImprintMapper was putting ISBNs into imprint.isbn, but after checking with Fleur, imprint doesn’t need an ISBN. So this PR stops mapping ISBN into imprint at all. All ISBNs still go to related_identifiers / Related Works, print, online, or no medium, that path was already fine. Added a test that imprint only keeps place and both print and online ISBNs land in related_identifiers.

I looked at IdentifiersMapper and RelatedIdentifiersMapper in identifiers.py, compared it to invenio.cfg, and basically only cds, aleph, cdsrn and apprn go to metadata.identifiers. Everything else like isbn, arxiv, urn, inspire, non CERN report numbers and extra dois go to metadata.related_identifiers, and the main doi goes to pids.doi, not those metadata fields. isbn used to go to identifiers wrongly but that’s already fixed, it only goes to related_identifiers. test_transformer.py covers this too.