### PR TITLE
feat(permissions): don't allow cross-community request viewing

### DIFF
--- a/invenio.cfg
+++ b/invenio.cfg
@@ -26,6 +26,7 @@ from cds_rdm.inspire_harvester.reader import InspireHTTPReader
 from cds_rdm.inspire_harvester.transformer import InspireJsonTransformer
 from cds_rdm.inspire_harvester.writer import InspireWriter
 from cds_rdm.vcs.handlers import gitlab_account_info_serializer
+from cds_rdm.requests import CDSCommunitySubmission, CDSCommunityInclusion
 from invenio_app_rdm.config import APP_RDM_ROUTES
 from invenio_app_rdm.config import \
     STATS_AGGREGATIONS as _APP_RDM_STATS_AGGREGATIONS
@@ -551,9 +552,10 @@ enforced across all enrolled communities.
 CHECKS_ENABLED = True
 """Enable metadata checks."""
 
-RDM_COMMUNITY_SUBMISSION_REQUEST_CLS = checks_requests.CommunitySubmission
+# CDS-specific permission overrides for submission/inclusion requests
+RDM_COMMUNITY_SUBMISSION_REQUEST_CLS = CDSCommunitySubmission
+RDM_COMMUNITY_INCLUSION_REQUEST_CLS = CDSCommunityInclusion
 
-RDM_COMMUNITY_INCLUSION_REQUEST_CLS = checks_requests.CommunityInclusion
 # require a community when publishing
 RDM_COMMUNITY_REQUIRED_TO_PUBLISH = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 license = "GPL-2.0"
 requires-python = ">=3.9"
 dependencies = [
-    "invenio-app-rdm[opensearch2]>=v15.0.0b2.dev1",
+    "invenio-app-rdm[opensearch2]>=v15.0.0b3.dev1",
     "invenio-cern-sync",
     "invenio-preservation-sync==0.5.0",
     "invenio-vcs>=0.0.1",

--- a/site/cds_rdm/generators.py
+++ b/site/cds_rdm/generators.py
@@ -13,7 +13,12 @@ from flask_principal import RoleNeed, UserNeed
 from invenio_access import action_factory
 from invenio_access.permissions import Permission, system_identity
 from invenio_rdm_records.services.generators import AccessGrant
-from invenio_records_permissions.generators import AuthenticatedUser, Generator
+from invenio_records_permissions.generators import (
+    AuthenticatedUser,
+    CompositeGenerator,
+    Generator,
+    SameAs,
+)
 from invenio_records_resources.services.errors import PermissionDeniedError
 from invenio_search.engine import dsl
 from invenio_users_resources.proxies import current_users_service
@@ -260,3 +265,43 @@ class CommitteeRefereeVersionGrant(Generator):
     def query_filter(self, identity=None, **kwargs):
         """Filter for records with a committee review grant for one of the identity's roles."""
         return COMMITTEE_APPROVAL_ACCESS_GRANT.query_filter(identity, kwargs=kwargs)
+
+
+class SameAsExcept(SameAs):
+    """Same as `SameAs` except it excludes the specified generators."""
+
+    def __init__(self, permission_name, exclude_generators: tuple[type]):
+        """
+        Constructor.
+
+        :param permission_name: Name of the permission attribute to delegate to.
+        :param exclude_generators: A tuple of generator class types to exclude. All generators that are instances of any of these classes will be excluded.
+        """
+        super().__init__(permission_name)
+        self.exclude_generators = exclude_generators
+
+    @staticmethod
+    def _flatten_generators(generators, **context):
+        """Recursively flatten the generators that belong to this composite generator."""
+        flat = []
+        for gen in generators:
+            if isinstance(gen, CompositeGenerator):
+                flat += SameAsExcept._flatten_generators(
+                    gen._generators(**context), **context
+                )
+                continue
+
+            flat.append(gen)
+
+        return flat
+
+    def _generators(self, **context):
+        """Return the filtered and flat list of generators."""
+        generators = SameAsExcept._flatten_generators(
+            super()._generators(**context), **context
+        )
+        return [
+            generator
+            for generator in generators
+            if not isinstance(generator, self.exclude_generators)
+        ]

--- a/site/cds_rdm/permissions.py
+++ b/site/cds_rdm/permissions.py
@@ -16,7 +16,10 @@ from invenio_jobs.services.permissions import JobLogsPermissionPolicy
 from invenio_preservation_sync.services.permissions import (
     DefaultPreservationInfoPermissionPolicy,
 )
-from invenio_rdm_records.services.generators import IfRecordDeleted
+from invenio_rdm_records.services.generators import (
+    IfRecordDeleted,
+    RecordCommunitiesAction,
+)
 from invenio_rdm_records.services.permissions import (
     RDMRecordPermissionPolicy,
     RDMRequestsPermissionPolicy,
@@ -34,6 +37,7 @@ from .generators import (
     HarvesterCurator,
     InspireHarvester,
     Librarian,
+    SameAsExcept,
 )
 
 
@@ -106,6 +110,12 @@ class CDSRDMRecordPermissionPolicy(RDMRecordPermissionPolicy):
             else_=can_read + [ArchiverRead()],
         )
     ]
+
+    # Don't allow curators (& above) of communities to view requests on a record that have a different community
+    # as a receiver, by using the record `can_preview` permission but without the `RecordCommunitiesAction` generator.
+    can_view_request = SameAsExcept(
+        "can_preview", exclude_generators=(RecordCommunitiesAction,)
+    )
 
     can_manage_clc_sync = [Librarian(), Administration(), SystemProcess()]
 

--- a/site/cds_rdm/requests/__init__.py
+++ b/site/cds_rdm/requests/__init__.py
@@ -9,5 +9,11 @@
 """CDS RDM request types."""
 
 from .committee_approval import CommitteeApprovalRequest
+from .community_inclusion import CDSCommunityInclusion
+from .community_submission import CDSCommunitySubmission
 
-__all__ = ["CommitteeApprovalRequest"]
+__all__ = [
+    "CommitteeApprovalRequest",
+    "CDSCommunityInclusion",
+    "CDSCommunitySubmission",
+]

--- a/site/cds_rdm/requests/community_inclusion.py
+++ b/site/cds_rdm/requests/community_inclusion.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2026 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the GPL-2.0 License; see LICENSE file for more details.
+
+"""CDS-specific Community Inclusion request."""
+
+from invenio_rdm_records.checks import requests as checks_request
+
+
+class CDSCommunityInclusion(checks_request.CommunityInclusion):
+    """CommunityInclusion with narrowed permissions."""
+
+    needs_context = checks_request.CommunityInclusion.needs_context | {
+        "record_permission": "view_request"
+    }

--- a/site/cds_rdm/requests/community_submission.py
+++ b/site/cds_rdm/requests/community_submission.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2026 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the GPL-2.0 License; see LICENSE file for more details.
+
+"""CDS-specific Community Submission request."""
+
+from invenio_rdm_records.checks import requests as checks_request
+
+
+class CDSCommunitySubmission(checks_request.CommunitySubmission):
+    """CommunitySubmission with narrowed permissions."""
+
+    needs_context = checks_request.CommunitySubmission.needs_context | {
+        "record_permission": "view_request"
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -1010,7 +1010,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cds-rdm", editable = "site" },
-    { name = "invenio-app-rdm", extras = ["opensearch2"], specifier = ">=15.0.0b2.dev1" },
+    { name = "invenio-app-rdm", extras = ["opensearch2"], specifier = ">=15.0.0b3.dev1" },
     { name = "invenio-cern-sync", git = "https://github.com/CERNDocumentServer/invenio-cern-sync?rev=v0.8.0" },
     { name = "invenio-preservation-sync", specifier = "==0.5.0" },
     { name = "invenio-vcs", specifier = ">=0.0.1" },


### PR DESCRIPTION
Closes #956 

---

* Added a new generator `SameAsExcept` which is the same as `SameAs` but
excludes generators that are an instance of a certain class.

* Created a new permission in the record permission policy which is the
same as `can_preview` except the `RecordCommunitiesAction("curate")`, so
only members of the community receiving an inclusion/submission request
can view it. Other communities to which the record belongs cannot view
requests that aren't received by them.

* Set this permission in new overrides of the `CommunityInclusion` and
`CommunitySubmission` classes.