### PR TITLE
fix(harvester): allow metadata-only create when INSPIRE has no files

### DIFF
--- a/site/cds_rdm/permissions.py
+++ b/site/cds_rdm/permissions.py
@@ -116,7 +116,8 @@ class CDSRDMRecordPermissionPolicy(RDMRecordPermissionPolicy):
     ]
 
     can_manage_files = RDMRecordPermissionPolicy.can_manage_files + [
-        AllowMetadataOnlyForCurators()
+        AllowMetadataOnlyForCurators(),
+        InspireHarvester(),
     ]
 
 


### PR DESCRIPTION
closes https://github.com/CERNDocumentServer/cds-rdm/issues/952

when we harvest an inspire record that has no files, we try to mark it as metadata only (no files needed). cds normally doesnt let people do that, and the harvester got blocked by the same rule, so the record still looked like it should have files, had none, and failed on publish. this pr just adds InspireHarvester() to can_manage_files so those records can be imported as metadata only while normal users still cant.
