### PR TITLE
change(experiments): add aliases for NA65 and NA66

### DIFF
--- a/app_data/vocabularies/experiments.yaml
+++ b/app_data/vocabularies/experiments.yaml
@@ -6579,6 +6579,8 @@
     en: NA65
   description:
     en: 'Study of tau neutrino production'
+  props:
+    aliases: DsTau NA65
 - id: IS407
   title:
     en: IS407
@@ -6592,6 +6594,7 @@
     en: 'Apparatus for Meson and Baryon Experimental Research'
   props:
     link: https://nqf-m2.web.cern.ch/
+    aliases: AMBER NA66
 - id: S58
   title:
     en: S58


### PR DESCRIPTION
Closes https://github.com/CERNDocumentServer/cds-migrator-kit/issues/594

Closes https://github.com/CERNDocumentServer/cds-migrator-kit/issues/512

---

Adds the aliases so that the `693__e` values can be correctly matched to experiments.